### PR TITLE
Fix default boolean juju config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ options:
   enable_cors:
     type: boolean
     description: "Enable Cross-origin Resource Sharing (CORS) at the application level (required for SSO)"
-    default: "true"
+    default: true
   external_hostname:
     type: string
     description: "External hostname this discourse instance should respond to. Defaults to the deployed application name."


### PR DESCRIPTION
Since ops 1.5.3, the config check is stricter see
https://github.com/canonical/operator/pull/787

This PR intends to fix an issue in the enable_cors default value