### PR TITLE
Move the comment inside the ignore_files section for consistency, and fix indentation

### DIFF
--- a/.woke.yaml
+++ b/.woke.yaml
@@ -1,6 +1,7 @@
-# Ignore ingress charm library as it uses this non compliant terminology: whitelist.
 ignore_files:
- - lib/charms/nginx_ingress_integrator/v0/ingress.py
+  # Ignore ingress charm library as it uses non compliant terminology:
+  # whitelist.
+  - lib/charms/nginx_ingress_integrator/v0/ingress.py
 rules:
   # Ignore "master" - the database relation event received from the library
   # uses this terminology.


### PR DESCRIPTION
Make the `ignore_files` section consistent with the `rules` section in terms of comments and indentation.