### PR TITLE
Drop support for ingress specific configurations

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,10 +23,6 @@ options:
     type: boolean
     description: "Force SAML login (full screen, no local database logins)"
     default: false
-  max_body_size:
-    type: int
-    description: "Max allowed body-size (for file uploads) in megabytes, set to 0 to disable limits"
-    default: 20
   redis_host:
     type: string
     description: "Redis host name / IP"
@@ -140,7 +136,3 @@ options:
     type: string
     description: "Throttle level - blocks excessive usage by ip. Valid values: none, permissive, strict"
     default: none
-  tls_secret_name:
-    type: string
-    description: "The name of the K8s secret to be associated with the ingress resource."
-    default: ""

--- a/src/charm.py
+++ b/src/charm.py
@@ -91,11 +91,6 @@ class DiscourseCharm(CharmBase):
             "service-port": SERVICE_PORT,
             "session-cookie-max-age": 3600,
         }
-
-        if self.config["tls_secret_name"]:
-            ingress_config["tls-secret-name"] = self.config["tls_secret_name"]
-        if self.config["max_body_size"]:
-            ingress_config["max-body-size"] = self.config["max_body_size"]
         return ingress_config
 
     def _check_config_is_valid(self):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -305,8 +305,6 @@ class TestDiscourseK8sCharm(unittest.TestCase):
                     "s3_endpoint": "s3.endpoint",
                     "s3_region": "the-infinite-and-beyond",
                     "s3_secret_access_key": "s|kI0ure_k3Y",
-                    "tls_secret_name": "somesecret",
-                    "max_body_size": 1000,
                 }
             )
 
@@ -352,8 +350,6 @@ class TestDiscourseK8sCharm(unittest.TestCase):
         self.assertEqual(
             "discourse.local", self.harness.charm.ingress.config_dict["service-hostname"]
         )
-        self.assertEqual("somesecret", self.harness.charm.ingress.config_dict["tls-secret-name"])
-        self.assertEqual(1000, self.harness.charm.ingress.config_dict["max-body-size"])
 
     def test_db_relation(self):
         """


### PR DESCRIPTION
Drop support for configuration of the following ingress options via the charm:
* TLS secret name
* Max body size of the request
* These configurations can be set directly through `juju config` in the related ingress charm, providing a more standard way to do so.