### PR TITLE
Fix codespell check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [tool.bandit]
 exclude_dirs = ["/venv/"]
 [tool.bandit.assert_used]
-skips = ["tests/**/*.py"]
+skips = ["*tests/*.py"]
 
 # Testing tools configuration
 [tool.coverage.run]

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ commands =
     pydocstyle {[vars]src_path}
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
     # pflake8 wrapper supports config from pyproject.toml


### PR DESCRIPTION
codespell {toxinidir}/. breaks in tox v4