### PR TITLE
Add action for creating admin user

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -6,6 +6,6 @@ add-admin-user:
       description: User email.
     password:
       type: string
-      description: Password at least 15 characters long.
+      description: User password.
   required: [email, password]
 

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,11 @@
+add-admin-user:
+  description: Add a new admin user.
+  params:
+    email:
+      type: string
+      description: User email.
+    password:
+      type: string
+      description: Password at least 15 characters long.
+  required: [email, password]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ skips = ["*tests/*.py"]
 branch = true
 
 [tool.coverage.report]
-fail_under = 86
+fail_under = 87
 show_missing = true
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -474,7 +474,7 @@ class DiscourseCharm(CharmBase):
             except ExecError as ex:
                 logger.error(ex)
                 event.fail(
-                    # Parameter validation erros are printed to stdout
+                    # Parameter validation errors are printed to stdout
                     f"Failed to create user with email {email}: {ex.stdout}"  # type: ignore
                 )
             event.set_results({"user": f"{email}"})

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,7 +13,7 @@ from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
 from charms.nginx_ingress_integrator.v0.ingress import IngressRequires
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.redis_k8s.v0.redis import RedisRelationCharmEvents, RedisRequires
-from ops.charm import CharmBase, HookEvent
+from ops.charm import ActionEvent, CharmBase, HookEvent
 from ops.framework import StoredState
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
@@ -25,6 +25,7 @@ pgsql = ops.lib.use("pgsql", 1, "postgresql-charmers@lists.launchpad.net")
 S3Info = namedtuple("S3Info", ["enabled", "region", "bucket", "endpoint"])
 
 DATABASE_NAME = "discourse"
+DISCOURSE_PATH = "/srv/discourse/app"
 THROTTLE_LEVELS = {
     "none": {
         "DISCOURSE_MAX_REQS_PER_IP_MODE": "none",
@@ -85,6 +86,7 @@ class DiscourseCharm(CharmBase):
             self.db.on.database_relation_joined, self._on_database_relation_joined
         )
         self.framework.observe(self.db.on.master_changed, self._on_database_changed)
+        self.framework.observe(self.on.add_admin_user_action, self._on_add_admin_user_action)
 
         self.redis = RedisRequires(self, self._stored)
         self.framework.observe(self.on.redis_relation_updated, self._config_changed)
@@ -151,7 +153,6 @@ class DiscourseCharm(CharmBase):
 
         if errors:
             self.model.unit.status = BlockedStatus(", ".join(errors))
-
         return not errors
 
     def _get_saml_config(self) -> Dict[str, Any]:
@@ -193,12 +194,7 @@ class DiscourseCharm(CharmBase):
         Returns:
             List of required fields that are either not present or empty.
         """
-        needed_fields = [
-            "cors_origin",
-            "developer_emails",
-            "smtp_address",
-            "smtp_domain",
-        ]
+        needed_fields = ["cors_origin"]
         return [field for field in needed_fields if not self.config.get(field)]
 
     def _get_s3_env(self) -> Dict[str, Any]:
@@ -452,6 +448,34 @@ class DiscourseCharm(CharmBase):
             self._stored.db_host = event.master.host
 
         self._config_changed(event)
+
+    def _on_add_admin_user_action(self, event: ActionEvent) -> None:
+        """Add a new admin user to Discourse.
+
+        Args:
+            event: Event triggering the add_admin_user action.
+        """
+        email = event.params["email"]
+        password = event.params["password"]
+        container = self.unit.get_container("discourse")
+        if container.can_connect():
+            process = container.exec(
+                [
+                    "bash",
+                    "-c",
+                    f"./bin/bundle exec rake admin:create <<< $'{email}\n{password}\n{password}\nY'",
+                ],
+                user="discourse",
+                working_dir=DISCOURSE_PATH,
+                environment=self._create_discourse_environment_settings(),
+            )
+            try:
+                process.wait_output()
+            except ExecError as ex:
+                event.fail(
+                    f"Failed to create user with email {email}: {ex.stderr.decode('utf-8')}"  # type: ignore
+                )
+            event.set_results({"user": f"{email}"})
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/charm.py
+++ b/src/charm.py
@@ -472,8 +472,10 @@ class DiscourseCharm(CharmBase):
             try:
                 process.wait_output()
             except ExecError as ex:
+                logger.error(ex)
                 event.fail(
-                    f"Failed to create user with email {email}: {ex.stderr.decode('utf-8')}"  # type: ignore
+                    # Parameter validation erros are printed to stdout
+                    f"Failed to create user with email {email}: {ex.stdout}"  # type: ignore
                 )
             event.set_results({"user": f"{email}"})
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -471,13 +471,13 @@ class DiscourseCharm(CharmBase):
             )
             try:
                 process.wait_output()
+                event.set_results({"user": f"{email}"})
             except ExecError as ex:
                 logger.error(ex)
                 event.fail(
                     # Parameter validation errors are printed to stdout
                     f"Failed to create user with email {email}: {ex.stdout}"  # type: ignore
                 )
-            event.set_results({"user": f"{email}"})
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/unit/_patched_charm.py
+++ b/tests/unit/_patched_charm.py
@@ -58,3 +58,4 @@ class _PGSQLPatch:
 pgsql_patch = _PGSQLPatch()
 DiscourseCharm = __import__("charm").DiscourseCharm
 SCRIPT_PATH = __import__("charm").SCRIPT_PATH
+DISCOURSE_PATH = __import__("charm").DISCOURSE_PATH


### PR DESCRIPTION
Add action for creating admin user. The action requires emails and password as parameters.
Also removes the requirement of having set up the SMTP settings for the charm to reach active status