### PR TITLE
feat(ISD-302): Add chaos testing

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,3 +10,6 @@ jobs:
     with:
       extra-arguments: --s3-url http://172.17.0.1:4566
       pre-run-script: localstack-installation.sh
+      chaos-enabled: true
+      chaos-experiments: pod-delete
+      chaos-app-label: app.kubernetes.io/name=discourse-k8s


### PR DESCRIPTION
This PR enables chaos testing for the discourse charm, a basic pod-delete test is invoked via operator-workflows.
The same approach has been already taken in Indico charm.