### PR TITLE
Feature/add jira integration

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   issues-to-jira:
-    uses: beliaev-maksim/github-to-jira-automation/blob/master/.github/workflows/issues_to_jira.yaml@main
+    uses: beliaev-maksim/github-to-jira-automation/.github/workflows/issues_to_jira.yaml@master
     secrets: inherit

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,0 +1,11 @@
+name: Sync issues to Jira
+
+on:
+  issues:
+    # available via github.event.action
+    types: [opened, reopened, closed]
+
+jobs:
+  issues-to-jira:
+    uses: beliaev-maksim/github-to-jira-automation/blob/master/.github/workflows/issues_to_jira.yaml@main
+    secrets: inherit


### PR DESCRIPTION
This feature adds an action to sync issues from Github to Jira. A JIRA_URL secrets is already created and the Automation on the side of Jira is configured as well. The sync is unidirectional, from Github to Jira, meaning creating/closing/reopening an issue on Github does that action on Jira, there is no Jira to Github direction.