### PR TITLE
fix(jira): Point to reusable workflow

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   issues-to-jira:
-    uses: beliaev-maksim/github-to-jira-automation/.github/workflows/issues_to_jira.yaml@master
+    uses: canonical/operator-workflows/.github/workflows/jira.yaml@main
     secrets: inherit


### PR DESCRIPTION
This fix replaces the original action to sync Github issues to Jira with the one under `operator-workflows` that is created as a reusable action. The original action has to be copied in the repo that should make use of it, so it made sense to have it in operator-workflows and charm repos to consume it.