### PR TITLE
Fix docs link titles

### DIFF
--- a/docs/how-to-guides/container-configuration.md
+++ b/docs/how-to-guides/container-configuration.md
@@ -1,3 +1,5 @@
+# Container configuration
+
 This charm exposes several configurations to tweak the behaviour of discourse. These can by changes by running `juju config [charm_name] [configuration]=[value]`. Below you can find some of the options that will allow you to modify the charm's behaviour:
 
 * CORS policies can be modified with the settings [cors_origin](https://charmhub.io/discourse-k8s/configure#cors_origin) and [enable_cors](https://charmhub.io/discourse-k8s/configure#enable_cors)

--- a/docs/how-to-guides/contributing.md
+++ b/docs/how-to-guides/contributing.md
@@ -1,3 +1,5 @@
+# Contributing
+
 This document explains the processes and practices recommended for contributing enhancements to the Discourse operator.
 
 * Generally, before developing enhancements to this charm, you should consider [opening an issue](https://github.com/canonical/discourse-k8s-operator/issues) explaining your use case.

--- a/docs/how-to-guides/hostname-configuration.md
+++ b/docs/how-to-guides/hostname-configuration.md
@@ -1,3 +1,5 @@
+# Hostname configuration
+
 This charm exposes the `external_hostname` configuration option to specify the external hostname of the application.
 
 To expose the application it is recommended to set that configuration option and deploy and relate the [Nginx Ingress Integrator Operator](https://charmhub.io/nginx-ingress-integrator), that will be automatically configured with the values provided by the charm.

--- a/docs/how-to-guides/s3-configuration.md
+++ b/docs/how-to-guides/s3-configuration.md
@@ -1,3 +1,5 @@
+# S3 configuration
+
 An S3 bucket can be leveraged to serve the static resources packaged by Discourse, potentically improving performance. Moreover, it is required when scaling the charm to serve the uploaded files. To configure it to set the following configuration options with the appropriate values for your existing bucket `juju config [charm_name] [configuration]=[value]`:
 
 ```

--- a/docs/how-to-guides/saml-configuration.md
+++ b/docs/how-to-guides/saml-configuration.md
@@ -1,3 +1,5 @@
+# SAML configuration
+
 To configure Discourse's SAML integration you'll have to set the following configuration options with the appropriate values for your SAML server by running `juju config [charm_name] [configuration]=[value]`.
 
 The SAML URL needs to be scpecified in `saml_target_url`. If you wish to force the login to go through SAML, enable `force_saml_login`.

--- a/docs/how-to-guides/smtp-configuration.md
+++ b/docs/how-to-guides/smtp-configuration.md
@@ -1,3 +1,5 @@
+# SMTP configuration
+
 To configure Discourse's SMTP you'll have to set the following configuration options with the appropriate values for your SMTP server by running `juju config [charm_name] [configuration]=[value]`.
 
 Set `smtp_address`to the SMTP server IP or hostname, `smtp_port` for the SMTP sever port if different from the default and `smtp_domain` to set the sender domain address.

--- a/docs/how-to-guides/upgrades.md
+++ b/docs/how-to-guides/upgrades.md
@@ -1,3 +1,5 @@
+# Upgrades
+
 Upgrades are done just by running the `juju refresh` subcommand. Juju, Kubernetes, and Discourse then work together to ensure that one pod is upgraded to the new version and makes any database schema changes before the rest of the pods are upgraded in their turn.
 
 ## Upgrading from pod-spec to sidecar

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,3 +1,5 @@
+# Getting started
+
 In this tutorial, we'll walk you through the process of deploying the Discourse charm, relating it to the nginx-ingress-integrator charm, the postgresql-k8s charm and the redis-k8s charm, and inspecting the kubernetes resources created.
 
 ## Requirements


### PR DESCRIPTION
Charmhub requires a title per document to be able to name the left index appropriately.