### PR TITLE
fix: restart after assets compile

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -301,7 +301,7 @@ class DiscourseCharm(CharmBase):
             "summary": "Discourse layer",
             "description": "Discourse layer",
             "services": {
-                "discourse": {
+                SERVICE_NAME: {
                     "override": "replace",
                     "summary": "Discourse web application",
                     "command": f"sh -c '{SCRIPT_PATH}/app_launch.sh'",
@@ -446,8 +446,8 @@ class DiscourseCharm(CharmBase):
         if self._is_config_valid() and container.can_connect():
             layer_config = self._create_layer_config()
             container.add_layer(SERVICE_NAME, layer_config, combine=True)
-            container.stop("discourse")
-            container.start("discourse")
+            container.stop(SERVICE_NAME)
+            container.start(SERVICE_NAME)
             self.ingress.update_config(self._make_ingress_config())
 
     def _redis_relation_changed(self, _: HookEvent) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -372,21 +372,21 @@ class DiscourseCharm(CharmBase):
         try:
             if self.model.unit.is_leader():
                 self.model.unit.status = MaintenanceStatus("Executing migrations")
-                process: ExecProcess = container.exec(
+                migration_process: ExecProcess = container.exec(
                     [f"{DISCOURSE_PATH}/bin/bundle", "exec", "rake", "--trace", "db:migrate"],
                     environment=env_settings,
                     working_dir=DISCOURSE_PATH,
                     user="discourse",
                 )
-                process.wait_output()
+                migration_process.wait_output()
             self.model.unit.status = MaintenanceStatus("Compiling assets")
-            process: ExecProcess = container.exec(
+            precompile_process: ExecProcess = container.exec(
                 [f"{DISCOURSE_PATH}/bin/bundle", "exec", "rake", "assets:precompile"],
                 environment=env_settings,
                 working_dir=DISCOURSE_PATH,
                 user="discourse",
             )
-            process.wait_output()
+            precompile_process.wait_output()
         except ExecError as cmd_err:
             logger.exception("Setting up discourse failed with code %d.", cmd_err.exit_code)
             raise

--- a/src/charm.py
+++ b/src/charm.py
@@ -446,7 +446,8 @@ class DiscourseCharm(CharmBase):
         if self._is_config_valid() and container.can_connect():
             layer_config = self._create_layer_config()
             container.add_layer(SERVICE_NAME, layer_config, combine=True)
-            # Currently, pebble replan will cause ChangError("cannot start service while terminating".)
+            # Currently, pebble replan will cause
+            # ChangeError("cannot start service while terminating".)
             # Link to issue: https://github.com/canonical/pebble/issues/206
             container.stop(SERVICE_NAME)
             container.start(SERVICE_NAME)

--- a/src/charm.py
+++ b/src/charm.py
@@ -446,6 +446,8 @@ class DiscourseCharm(CharmBase):
         if self._is_config_valid() and container.can_connect():
             layer_config = self._create_layer_config()
             container.add_layer(SERVICE_NAME, layer_config, combine=True)
+            # Currently, pebble replan will cause ChangError("cannot start service while terminating".)
+            # Link to issue: https://github.com/canonical/pebble/issues/206
             container.stop(SERVICE_NAME)
             container.start(SERVICE_NAME)
             self.ingress.update_config(self._make_ingress_config())

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -346,3 +346,21 @@ async def test_create_category(
 
     assert category["name"] == category_info["name"]
     assert category["color"] == category_info["color"]
+
+
+@pytest.mark.asyncio
+async def test_serve_compiled_assets(
+    discourse_address: str,
+):
+    """
+    arrange: Given discourse application
+    act: when accessing a page that does not exist
+    assert: a compiled asset should be served.
+    """
+    res = requests.get(f"{discourse_address}/404", timeout=60)
+    not_found_page = str(res.content)
+
+    asset_matches = re.search(
+        r"(onpopstate-handler).+.js", not_found_page
+    )  # a non-compiled asset will be named onpopstate-handler.js
+    assert asset_matches, "Compiled asset not found."


### PR DESCRIPTION
This PR addresses the problem where the service is not restarted after compiling assets, resulting in serving non-compiled assets, that will result in 404 while loading assets.

`container.replan()` fails to actually stop and start the service, hence the `container.stop()` followed by `container.start()`.

```
  File "./src/charm.py", line 451, in _reload_configuration
    container.replan()
  File "/var/lib/juju/agents/unit-discourse-k8s-0/charm/venv/ops/model.py", line 1877, in replan
    self._pebble.replan_services()
  File "/var/lib/juju/agents/unit-discourse-k8s-0/charm/venv/ops/pebble.py", line 1571, in replan_services
    return self._services_action('replan', [], timeout, delay)
  File "/var/lib/juju/agents/unit-discourse-k8s-0/charm/venv/ops/pebble.py", line 1652, in _services_action
    raise ChangeError(change.err, change)
ops.pebble.ChangeError: cannot perform the following tasks:
- Start service "discourse" (cannot start service while terminating)
```