### PR TITLE
Wait until the discourse setup is complete before starting the discourse server

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,6 +13,6 @@ jobs:
       chaos-enabled: true
       chaos-experiments: pod-delete
       chaos-status-duration: 300
-      extra-arguments: --s3-url http://172.17.0.1:4566 -m "not (requires_secrets)"
+      extra-arguments: --localstack-address 172.17.0.1 -m "not (requires_secrets)"
       pre-run-script: localstack-installation.sh
       trivy-image-config: "trivy.yaml"

--- a/localstack-installation.sh
+++ b/localstack-installation.sh
@@ -3,7 +3,7 @@
 pip install pip --upgrade
 pip install pyopenssl --upgrade
 pip install localstack # install LocalStack cli
-docker pull localstack/localstack:1.3.1
+docker pull localstack/localstack
 EDGE_BIND_HOST=0.0.0.0 localstack start -d # Start LocalStack in the background (binding to all host ip)
 echo "Waiting for LocalStack startup..." # Wait 30 seconds for the LocalStack container
 localstack wait -t 30 # to become ready before timing out 

--- a/localstack-installation.sh
+++ b/localstack-installation.sh
@@ -3,7 +3,7 @@
 pip install pip --upgrade
 pip install pyopenssl --upgrade
 pip install localstack # install LocalStack cli
-docker pull localstack/localstack
+docker pull localstack/localstack # Make sure to pull the latest version of the image
 EDGE_BIND_HOST=0.0.0.0 localstack start -d # Start LocalStack in the background (binding to all host ip)
 echo "Waiting for LocalStack startup..." # Wait 30 seconds for the LocalStack container
 localstack wait -t 30 # to become ready before timing out 

--- a/localstack-installation.sh
+++ b/localstack-installation.sh
@@ -3,7 +3,7 @@
 pip install pip --upgrade
 pip install pyopenssl --upgrade
 pip install localstack # install LocalStack cli
-docker pull localstack/localstack:1.4.0
+docker pull localstack/localstack:1.3.1
 EDGE_BIND_HOST=0.0.0.0 localstack start -d # Start LocalStack in the background (binding to all host ip)
 echo "Waiting for LocalStack startup..." # Wait 30 seconds for the LocalStack container
 localstack wait -t 30 # to become ready before timing out 

--- a/localstack-installation.sh
+++ b/localstack-installation.sh
@@ -3,7 +3,7 @@
 pip install pip --upgrade
 pip install pyopenssl --upgrade
 pip install localstack # install LocalStack cli
-docker pull localstack/localstack # Make sure to pull the latest version of the image
+docker pull localstack/localstack:1.4.0
 EDGE_BIND_HOST=0.0.0.0 localstack start -d # Start LocalStack in the background (binding to all host ip)
 echo "Waiting for LocalStack startup..." # Wait 30 seconds for the LocalStack container
 localstack wait -t 30 # to become ready before timing out 

--- a/src/charm.py
+++ b/src/charm.py
@@ -452,11 +452,7 @@ class DiscourseCharm(CharmBase):
         if self._is_config_valid() and container.can_connect():
             layer_config = self._create_layer_config()
             container.add_layer(SERVICE_NAME, layer_config, combine=True)
-            # Currently, pebble replan will cause
-            # ChangeError("cannot start service while terminating".)
-            # Link to issue: https://github.com/canonical/pebble/issues/206
-            container.stop(SERVICE_NAME)
-            container.start(SERVICE_NAME)
+            container.pebble.replan_services()
             self.ingress.update_config(self._make_ingress_config())
 
     def _redis_relation_changed(self, _: HookEvent) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -139,7 +139,7 @@ class DiscourseCharm(CharmBase):
     def _set_setup_completed(self) -> None:
         """Mark the _set_up_discourse process as completed."""
         SETUP_COMPLETED_FLAG_FILE.parent.mkdir(exist_ok=True)
-        pathlib.Path("/run/discourse-k8s-operator/setup_completed").touch(exist_ok=True)
+        SETUP_COMPLETED_FLAG_FILE.touch(exist_ok=True)
 
     def _is_config_valid(self) -> bool:
         """Check that the provided config is valid.

--- a/src/charm.py
+++ b/src/charm.py
@@ -444,7 +444,8 @@ class DiscourseCharm(CharmBase):
             self.model.unit.status = ActiveStatus()
 
     def _reload_configuration(self) -> None:
-        if not self._stored.setup_completed:
+        # mypy has some trouble with dynamic attributes
+        if not self._stored.setup_completed:  # type: ignore
             logger.info("Defer starting the discourse server until discourse setup completed")
             return
         container = self.unit.get_container(SERVICE_NAME)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,6 @@
 def pytest_addoption(parser):
     """Adds parser switches."""
     parser.addoption("--discourse-image", action="store")
-    parser.addoption("--s3-url", action="store")
+    parser.addoption("--localstack-address", action="store")
     parser.addoption("--saml-email", action="store")
     parser.addoption("--saml-password", action="store")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -49,11 +49,12 @@ def fixture_app_config():
 
 
 @fixture(scope="module")
-def s3_url(pytestconfig: Config):
-    """Provides S3 IP address to inject to discourse hosts"""
-    yield pytestconfig.getoption("--s3-url") if pytestconfig.getoption(
-        "--s3-url"
-    ) else "http://127.0.0.1:4566"
+def localstack_address(pytestconfig: Config):
+    """Provides localstack IP address to be used in the integration test"""
+    address = pytestconfig.getoption("--localstack-address")
+    if not address:
+        raise ValueError("--localstack-address argument is required for selected test cases")
+    yield address
 
 
 @fixture(scope="module")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -166,7 +166,7 @@ async def test_s3_conf(app: Application, s3_url: str, model: Model):
         s3_conf["region"],
         aws_access_key_id=s3_conf["credentials"]["access-key"],
         aws_secret_access_key=s3_conf["credentials"]["secret-key"],
-        endpoint_url=s3_conf["endpoint"],
+        endpoint_url=s3_url,
         use_ssl=False,
         config=s3_client_config,
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -8,7 +8,6 @@ import re
 import socket
 import unittest.mock
 from typing import Dict
-from urllib.parse import urlparse
 
 import pytest
 import requests
@@ -99,14 +98,14 @@ async def test_setup_discourse(
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_s3_conf(app: Application, s3_url: str, model: Model):
+async def test_s3_conf(app: Application, localstack_address: str, model: Model):
     """Check that the bootstrap page is reachable
     with the charm configured with an S3 target
     Assume that the charm has already been built and is running.
     This test requires a localstack deployed
     """
 
-    s3_conf: Dict = generate_s3_config(s3_url)
+    s3_conf: Dict = generate_s3_config(localstack_address)
 
     logger.info("Updating discourse hosts")
 
@@ -120,16 +119,12 @@ async def test_s3_conf(app: Application, s3_url: str, model: Model):
     assert result.results.get("return-code") == 0, "Can't inject S3 IP in Discourse hosts"
 
     logger.info("Injected bucket subdomain in hosts, configuring settings for discourse")
-    charm_s3_endpoint = s3_conf["endpoint"]
-    charm_s3_endpoint = urlparse(charm_s3_endpoint)
-    charm_s3_endpoint = charm_s3_endpoint._replace(netloc=f"s3.{charm_s3_endpoint.netloc}")
-    charm_s3_endpoint = charm_s3_endpoint.geturl()
     # Application does actually have attribute set_config
     await app.set_config(  # type: ignore
         {
             "s3_enabled": "true",
             # The final URL is computed by discourse, we need to pass the main URL
-            "s3_endpoint": charm_s3_endpoint,
+            "s3_endpoint": s3_conf["endpoint"],
             "s3_bucket": s3_conf["bucket"],
             "s3_secret_access_key": s3_conf["credentials"]["secret-key"],
             "s3_access_key_id": s3_conf["credentials"]["access-key"],
@@ -155,7 +150,7 @@ async def test_s3_conf(app: Application, s3_url: str, model: Model):
         s3_conf["region"],
         aws_access_key_id=s3_conf["credentials"]["access-key"],
         aws_secret_access_key=s3_conf["credentials"]["secret-key"],
-        endpoint_url=s3_url,
+        endpoint_url=f"http://{localstack_address}:4566",
         use_ssl=False,
         config=s3_client_config,
     )
@@ -188,26 +183,18 @@ async def test_s3_conf(app: Application, s3_url: str, model: Model):
     await model.wait_for_idle(status="active")
 
 
-def generate_s3_config(s3_url: str) -> Dict:
+def generate_s3_config(localstack_address: str) -> Dict:
     """Generate an S3 config for localstack based test."""
-    s3_config: Dict = {
+    return {
         # Localstack doesn't require any specific value there, any random string will work
         "credentials": {"access-key": "my-lovely-key", "secret-key": "this-is-very-secret"},
         # Localstack enforce to use this domain and it resolves to localhost
         "domain": "localhost.localstack.cloud",
         "bucket": "tests",
         "region": "us-east-1",
+        "ip_address": localstack_address,
+        "endpoint": "http://s3.localhost.localstack.cloud:4566",
     }
-
-    # Parse URL to get the IP address and the port, and compose the required variables
-    parsed_s3_url = urlparse(s3_url)
-    s3_ip_address = parsed_s3_url.hostname
-    s3_endpoint = f"{parsed_s3_url.scheme}://{s3_config['domain']}"
-    if parsed_s3_url:
-        s3_endpoint = f"{s3_endpoint}:{parsed_s3_url.port}"
-    s3_config["ip_address"] = s3_ip_address
-    s3_config["endpoint"] = s3_endpoint
-    return s3_config
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -149,17 +149,6 @@ async def test_s3_conf(app: Application, s3_url: str, model: Model):
         },
     )
 
-    # Trick to use when localstack is deployed on another location than locally
-    if s3_conf["ip_address"] != "127.0.0.1":
-        proxy_definition = {
-            "http": s3_url,
-        }
-        s3_client_config = s3_client_config.merge(
-            Config(
-                proxies=proxy_definition,
-            )
-        )
-
     # Configure the boto client
     s3_client = client(
         "s3",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -209,7 +209,7 @@ class TestDiscourseK8sCharm(unittest.TestCase):
         assert: the appropriate configuration values are passed to the pod and the unit
             reaches Active status.
         """
-        self.harness.begin()
+        self.harness.begin_with_initial_hooks()
         self.harness.disable_hooks()
         self.harness.set_leader(True)
         self._add_database_relations()
@@ -224,6 +224,7 @@ class TestDiscourseK8sCharm(unittest.TestCase):
             }
         )
         self.harness.container_pebble_ready("discourse")
+        self.harness.framework.reemit()
 
         updated_plan = self.harness.get_container_pebble_plan("discourse").to_dict()
         updated_plan_env = updated_plan["services"]["discourse"]["environment"]
@@ -264,7 +265,7 @@ class TestDiscourseK8sCharm(unittest.TestCase):
         assert: the appropriate configuration values are passed to the pod and the unit
             reaches Active status.
         """
-        self.harness.begin()
+        self.harness.begin_with_initial_hooks()
         self.harness.disable_hooks()
         self._add_database_relations()
         with self._patch_exec():
@@ -278,6 +279,7 @@ class TestDiscourseK8sCharm(unittest.TestCase):
                 }
             )
             self.harness.container_pebble_ready("discourse")
+            self.harness.framework.reemit()
 
         updated_plan = self.harness.get_container_pebble_plan("discourse").to_dict()
         updated_plan_env = updated_plan["services"]["discourse"]["environment"]
@@ -314,7 +316,7 @@ class TestDiscourseK8sCharm(unittest.TestCase):
         assert: the appropriate configuration values are passed to the pod and the unit
             reaches Active status.
         """
-        self.harness.begin()
+        self.harness.begin_with_initial_hooks()
         self.harness.disable_hooks()
         self._add_database_relations()
         with self._patch_exec():
@@ -342,6 +344,7 @@ class TestDiscourseK8sCharm(unittest.TestCase):
                 }
             )
             self.harness.container_pebble_ready("discourse")
+            self.harness.framework.reemit()
 
         updated_plan = self.harness.get_container_pebble_plan("discourse").to_dict()
         updated_plan_env = updated_plan["services"]["discourse"]["environment"]
@@ -480,11 +483,12 @@ class TestDiscourseK8sCharm(unittest.TestCase):
         act: trigger the install event on a leader unit
         assert: migrations are executed and assets are precompiled.
         """
-        self.harness.begin()
+        self.harness.begin_with_initial_hooks()
         self.harness.set_leader(True)
         self._add_database_relations()
         self.harness.container_pebble_ready("discourse")
         self.harness.charm.on.install.emit()
+        self.harness.framework.reemit()
 
         updated_plan = self.harness.get_container_pebble_plan("discourse").to_dict()
         updated_plan_env = updated_plan["services"]["discourse"]["environment"]
@@ -508,11 +512,11 @@ class TestDiscourseK8sCharm(unittest.TestCase):
         act: trigger the install event on a leader unit
         assert: migrations are executed and assets are precompiled.
         """
-        self.harness.begin()
+        self.harness.begin_with_initial_hooks()
         self.harness.set_leader(False)
         self._add_database_relations()
         self.harness.container_pebble_ready("discourse")
-        self.harness.charm.on.install.emit()
+        self.harness.framework.reemit()
 
         updated_plan = self.harness.get_container_pebble_plan("discourse").to_dict()
         updated_plan_env = updated_plan["services"]["discourse"]["environment"]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -204,30 +204,30 @@ class TestDiscourseK8sCharm(unittest.TestCase):
             BlockedStatus("'s3_enabled' requires 's3_bucket'"),
         )
 
-    @patch.object(Container, "exec")
-    def test_config_changed_when_valid_no_s3_backup_nor_cdn(self, mock_exec):
+    def test_config_changed_when_valid_no_s3_backup_nor_cdn(self):
         """
         arrange: given a deployed discourse charm with all the required relations
         act: when a valid configuration is provided
         assert: the appropriate configuration values are passed to the pod and the unit
             reaches Active status.
         """
-        self.harness.begin_with_initial_hooks()
-        self.harness.disable_hooks()
-        self.harness.set_leader(True)
-        self._add_database_relations()
-        self.harness.update_config(
-            {
-                "s3_access_key_id": "3|33+",
-                "s3_bucket": "who-s-a-good-bucket?",
-                "s3_enabled": True,
-                "s3_endpoint": "s3.endpoint",
-                "s3_region": "the-infinite-and-beyond",
-                "s3_secret_access_key": "s|kI0ure_k3Y",
-            }
-        )
-        self.harness.container_pebble_ready("discourse")
-        self.harness.framework.reemit()
+        with self._patch_exec() as mock_exec:
+            self.harness.begin_with_initial_hooks()
+            self.harness.disable_hooks()
+            self.harness.set_leader(True)
+            self._add_database_relations()
+            self.harness.update_config(
+                {
+                    "s3_access_key_id": "3|33+",
+                    "s3_bucket": "who-s-a-good-bucket?",
+                    "s3_enabled": True,
+                    "s3_endpoint": "s3.endpoint",
+                    "s3_region": "the-infinite-and-beyond",
+                    "s3_secret_access_key": "s|kI0ure_k3Y",
+                }
+            )
+            self.harness.container_pebble_ready("discourse")
+            self.harness.framework.reemit()
 
         updated_plan = self.harness.get_container_pebble_plan("discourse").to_dict()
         updated_plan_env = updated_plan["services"]["discourse"]["environment"]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,7 +7,6 @@
 # Protected access check is disabled in tests as we're injecting test data
 
 import contextlib
-import pathlib
 import typing
 import unittest
 from unittest.mock import MagicMock, patch
@@ -58,16 +57,14 @@ class TestDiscourseK8sCharm(unittest.TestCase):
         """Patch filesystem calls in the _is_setup_completed and _set_setup_completed functions."""
         setup_completed = False
 
-        def is_file(*_args, **_kwargs):
+        def exists(*_args, **_kwargs):
             return setup_completed
 
-        def touch(*_args, **_kwargs):
+        def push(*_args, **_kwargs):
             nonlocal setup_completed
             setup_completed = True
 
-        with unittest.mock.patch.multiple(
-            pathlib.Path, is_file=is_file, touch=touch, parent=MagicMock()
-        ):
+        with unittest.mock.patch.multiple(Container, exists=exists, push=push):
             yield
 
     def test_relations_not_ready(self):


### PR DESCRIPTION
In the `_on_database_changed` callback, the function actually calls  `self._reload_configuration`, which starts the discourse server. However, since `_set_up_discourse` is deferred until the database is established, this causes `_reload_configuration` to run before `_set_up_discourse`, resulting in the discourse server starting without the database table being created.

Add a check in `_on_database_changed` to wait until discourse setup is finished.