### PR TITLE
Fix _are_db_relations_ready() and _get_redis_relation_data()

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -415,10 +415,7 @@ class DiscourseCharm(CharmBase):
         if not self._stored.redis_relation:  # type: ignore
             self.model.unit.status = WaitingStatus("Waiting for redis relation")
             return False
-        if (
-            self._get_redis_relation_data()[0] in ("", "None")
-            or self._get_redis_relation_data()[1] == 0
-        ):
+        if not all(self._get_redis_relation_data()):
             self.model.unit.status = WaitingStatus("Waiting for redis relation to initialize")
             return False
         return True

--- a/src/charm.py
+++ b/src/charm.py
@@ -292,16 +292,8 @@ class DiscourseCharm(CharmBase):
         for redis_unit in self._stored.redis_relation:  # type: ignore
             # mypy fails to see that this is indexable
             redis_unit_data = self._stored.redis_relation[redis_unit]  # type: ignore
-            try:
-                redis_hostname = str(redis_unit_data.get("hostname"))  # type: ignore
-            # I need to catch all exceptions that str() can throw
-            except Exception:  # pylint: disable=broad-exception-caught
-                redis_hostname = ""
-            try:
-                redis_port = int(redis_unit_data.get("port"))  # type: ignore
-            # I need to catch all exceptions that int() can throw
-            except Exception:  # pylint: disable=broad-exception-caught
-                redis_port = 0
+            redis_hostname = str(redis_unit_data.get("hostname", "") or "")
+            redis_port = int(redis_unit_data.get("port", 0) or 0)
             logger.debug(
                 "Got redis connection details from relation of %s:%s", redis_hostname, redis_port
             )

--- a/src/charm.py
+++ b/src/charm.py
@@ -436,6 +436,7 @@ class DiscourseCharm(CharmBase):
                 self.model.unit.status = WaitingStatus("Waiting for redis relation to initialize")
                 return False
         except MissingRedisRelationDataError:
+            self.model.unit.status = WaitingStatus("Waiting for redis relation to initialize")
             return False
         return True
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -301,8 +301,8 @@ class DiscourseCharm(CharmBase):
             try:
                 redis_hostname = str(redis_unit_data.get("hostname"))
                 redis_port = int(redis_unit_data.get("port"))
-            except (ValueError, TypeError):
-                raise MissingRedisRelationDataError()
+            except (ValueError, TypeError) as exc:
+                raise MissingRedisRelationDataError() from exc
 
             logger.debug(
                 "Got redis connection details from relation of %s:%s", redis_hostname, redis_port

--- a/src/charm.py
+++ b/src/charm.py
@@ -299,7 +299,8 @@ class DiscourseCharm(CharmBase):
                 redis_hostname = ""
             try:
                 redis_port = int(redis_unit_data.get("port"))  # type: ignore
-            except ValueError:
+            # I need to catch all exceptions that int() can throw
+            except Exception:  # pylint: disable=broad-exception-caught
                 redis_port = 0
             logger.debug(
                 "Got redis connection details from relation of %s:%s", redis_hostname, redis_port

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -634,13 +634,10 @@ class TestDiscourseK8sCharm(unittest.TestCase):
         for relation_data, should_be_ready in test_cases:
             with self.subTest(relation_data=relation_data, should_be_ready=should_be_ready):
                 self.start_harness(with_postgres=False, with_redis=False)
-                # get a relation ID for the test outside of __init__ (note pylint disable)
-                self.db_relation_id = (  # pylint: disable=attribute-defined-outside-init
-                    self.harness.add_relation("database", "postgresql")
-                )
-                self.harness.add_relation_unit(self.db_relation_id, "postgresql/0")
+                db_relation_id = self.harness.add_relation("database", "postgresql")
+                self.harness.add_relation_unit(db_relation_id, "postgresql/0")
                 self.harness.update_relation_data(
-                    self.db_relation_id,
+                    db_relation_id,
                     "postgresql",
                     relation_data,
                 )
@@ -695,10 +692,7 @@ class TestDiscourseK8sCharm(unittest.TestCase):
         for relation_data, should_be_ready in test_cases:
             with self.subTest(relation_data=relation_data, should_be_ready=should_be_ready):
                 self.start_harness(with_postgres=True, with_redis=False)
-                # get a relation ID for the test outside of __init__ (note pylint disable)
-                self.redis_relation_id = (  # pylint: disable=attribute-defined-outside-init
-                    self.harness.add_relation("redis", "redis")
-                )
-                self.harness.add_relation_unit(self.redis_relation_id, "redis/0")
-                self.harness.charm._stored.redis_relation = {self.redis_relation_id: relation_data}
+                redis_relation_id = self.harness.add_relation("redis", "redis")
+                self.harness.add_relation_unit(redis_relation_id, "redis/0")
+                self.harness.charm._stored.redis_relation = {redis_relation_id: relation_data}
                 self.assertEqual(should_be_ready, self.harness.charm._are_db_relations_ready())

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -665,7 +665,7 @@ class TestDiscourseK8sCharm(unittest.TestCase):
             ),
             (
                 {"hostname": "redis-host", "port": 0},
-                True,
+                False,
             ),
             (
                 {"hostname": "", "port": 1010},

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -664,6 +664,10 @@ class TestDiscourseK8sCharm(unittest.TestCase):
                 True,
             ),
             (
+                {"hostname": "redis-host", "port": 0},
+                True,
+            ),
+            (
                 {"hostname": "", "port": 1010},
                 False,
             ),


### PR DESCRIPTION
- `_get_redis_relation_data()` should *always* return a Tuple[str, int]
- `_are_db_relations_ready()` should return `False` on malformed redis relation data