### PR TITLE
Increase model deployment reliability

### DIFF
--- a/discourse.Dockerfile
+++ b/discourse.Dockerfile
@@ -105,4 +105,6 @@ RUN git clone https://github.com/discourse/discourse-saml.git "${PLUGINS_DIR}/di
     && su -s /bin/bash -c '${CONTAINER_APP_ROOT}/app/bin/bundle install --gemfile=${PLUGINS_DIR}/discourse-saml/Gemfile --path=${PLUGINS_DIR}/discourse-saml/gems' "${CONTAINER_APP_USERNAME}" \
     && ln -s "${PLUGINS_DIR}/discourse-saml/gems/ruby/"* "${PLUGINS_DIR}/discourse-saml/gems/" \
     && echo "gem 'prometheus_exporter', require: false" >> "${CONTAINER_APP_ROOT}/app/Gemfile" \
+    && sed -i 's/rexml (3.2.5)/rexml (3.2.6)/' "${CONTAINER_APP_ROOT}/app/Gemfile.lock" \
+    && echo "gem 'rexml', '3.2.6'" >> "${CONTAINER_APP_ROOT}/app/Gemfile" \
     && su -s /bin/bash -c '${CONTAINER_APP_ROOT}/app/bin/bundle install' "${CONTAINER_APP_USERNAME}"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -134,7 +134,9 @@ async def app_fixture(
     """
     # Deploy relations to speed up overall execution
 
-    postgres_app = await model.deploy("postgresql-k8s", channel="14/edge", series="jammy", trust=True)
+    postgres_app = await model.deploy(
+        "postgresql-k8s", channel="14/edge", series="jammy", trust=True
+    )
     await model.wait_for_idle(apps=[postgres_app.name], status="active")
 
     redis_app = await model.deploy("redis-k8s", series="jammy", channel="latest/edge")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -135,7 +135,7 @@ async def app_fixture(
     # Deploy relations to speed up overall execution
 
     postgres_app = await model.deploy(
-        "postgresql-k8s", channel="14/edge", series="jammy", revision=116, trust=True
+        "postgresql-k8s", channel="14/beta", series="jammy", trust=True
     )
     await model.wait_for_idle(apps=[postgres_app.name], status="active")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -135,7 +135,11 @@ async def app_fixture(
     # Deploy relations to speed up overall execution
 
     postgres_app = await model.deploy(
-        "postgresql-k8s", channel="14/edge", series="jammy", trust=True
+        "postgresql-k8s",
+        channel="14/edge",
+        series="jammy",
+        revision=116,
+        trust=True
     )
     await model.wait_for_idle(apps=[postgres_app.name], status="active")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -135,11 +135,7 @@ async def app_fixture(
     # Deploy relations to speed up overall execution
 
     postgres_app = await model.deploy(
-        "postgresql-k8s",
-        channel="14/edge",
-        series="jammy",
-        revision=116,
-        trust=True
+        "postgresql-k8s", channel="14/edge", series="jammy", revision=116, trust=True
     )
     await model.wait_for_idle(apps=[postgres_app.name], status="active")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -132,8 +132,10 @@ async def app_fixture(
     """Discourse charm used for integration testing.
     Builds the charm and deploys it and the relations it depends on.
     """
-    # Deploy relations to speed up overall execution
-
+    # We're using the '14/beta' channel here because of some hooks issues
+    # encountered on rev117 of the charm.
+    # https://github.com/canonical/discourse-k8s-operator/actions/runs/5800833433/job/15724726551#step:12:68
+    # We should switch back to '14/edge' when this is solved.
     postgres_app = await model.deploy(
         "postgresql-k8s", channel="14/beta", series="jammy", trust=True
     )


### PR DESCRIPTION
I separated the deployment of related apps to gave them more time to stabilize and having a clear target when they provoke an error or timeouts to the model.

Postgresql-k8s is switched to the 14/beta channel to fix this issue:
- https://github.com/canonical/discourse-k8s-operator/actions/runs/5800833433/job/15724726551#step:12:68

The `rexml` dockerfile change is here to fix those issues:
- https://github.com/canonical/discourse-k8s-operator/actions/runs/5815067357/job/15765929740?pr=84#step:8:2316
- https://github.com/canonical/discourse-k8s-operator/actions/runs/5815067431/job/15766156828?pr=84#step:12:169