### PR TITLE
Force S3 uploads

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -511,6 +511,10 @@ class DiscourseCharm(CharmBase):
                 else "",
             )
         env_settings = self._create_discourse_environment_settings()
+        if self.config.get("s3_enabled"):
+            # We force assets to be uploaded to S3
+            # This should be considered as a workaround and revisited later
+            env_settings.update({"FORCE_S3_UPLOADS": "true"})
         try:
             if self.model.unit.is_leader() and self._should_run_s3_migration(
                 current_plan, previous_s3_info

--- a/src/charm.py
+++ b/src/charm.py
@@ -283,6 +283,10 @@ class DiscourseCharm(CharmBase):
             s3_env["DISCOURSE_S3_BACKUP_BUCKET"] = self.config["s3_backup_bucket"]
         if self.config.get("s3_cdn_url"):
             s3_env["DISCOURSE_S3_CDN_URL"] = self.config["s3_cdn_url"]
+        if self.config.get("s3_enabled"):
+            # We force assets to be uploaded to S3
+            # This should be considered as a workaround and revisited later
+            s3_env["FORCE_S3_UPLOADS"] = "true"
 
         return s3_env
 
@@ -511,10 +515,6 @@ class DiscourseCharm(CharmBase):
                 else "",
             )
         env_settings = self._create_discourse_environment_settings()
-        if self.config.get("s3_enabled"):
-            # We force assets to be uploaded to S3
-            # This should be considered as a workaround and revisited later
-            env_settings.update({"FORCE_S3_UPLOADS": "true"})
         try:
             if self.model.unit.is_leader() and self._should_run_s3_migration(
                 current_plan, previous_s3_info


### PR DESCRIPTION
This adds a workaround for assets being skipped during the s3:upload_assets process.  
It should be revisited later when upgrading to a new version of discourse.