### PR TITLE
Change prometheus_exporter binding to 0.0.0.0

### DIFF
--- a/image/scripts/app_launch.sh
+++ b/image/scripts/app_launch.sh
@@ -5,7 +5,7 @@
 export UNICORN_BIND_ALL=0.0.0.0
 export UNICORN_SIDEKIQS=1
 
-su -s /bin/bash -c "${CONTAINER_APP_ROOT}/app/bin/bundle exec prometheus_exporter" &
+su -s /bin/bash -c "${CONTAINER_APP_ROOT}/app/bin/bundle exec prometheus_exporter -b 0.0.0.0" &
 su -s /bin/bash -c "${CONTAINER_APP_ROOT}/app/bin/unicorn -c ${CONTAINER_APP_ROOT}/app/config/unicorn.conf.rb" "${CONTAINER_APP_USERNAME}" &
 
 # If one of the processes exits, the other one will be killed so that the pod will be restarted by the failing probes


### PR DESCRIPTION
Change the default binding from the prometheus_exporter from 127.0.0.1 to 0.0.0.0 in order to make metrics available externally.