### PR TITLE
Install needed gems for the discourse-prometheus plugin

### DIFF
--- a/discourse.Dockerfile
+++ b/discourse.Dockerfile
@@ -105,6 +105,8 @@ RUN git clone https://github.com/discourse/discourse-saml.git "${PLUGINS_DIR}/di
     && su -s /bin/bash -c 'gem install bundler' "${CONTAINER_APP_USERNAME}" \
     && su -s /bin/bash -c '${CONTAINER_APP_ROOT}/app/bin/bundle install --gemfile=${PLUGINS_DIR}/discourse-saml/Gemfile --path=${PLUGINS_DIR}/discourse-saml/gems' "${CONTAINER_APP_USERNAME}" \
     && ln -s "${PLUGINS_DIR}/discourse-saml/gems/ruby/"* "${PLUGINS_DIR}/discourse-saml/gems/" \
+    && su -s /bin/bash -c '${CONTAINER_APP_ROOT}/app/bin/bundle install --gemfile=${PLUGINS_DIR}/discourse-prometheus/Gemfile --path=${PLUGINS_DIR}/discourse-prometheus/gems' "${CONTAINER_APP_USERNAME}" \
+    && ln -s "${PLUGINS_DIR}/discourse-prometheus/gems/ruby/"* "${PLUGINS_DIR}/discourse-prometheus/gems/" \
     && sed -i 's/rexml (3.2.5)/rexml (3.2.6)/' "${CONTAINER_APP_ROOT}/app/Gemfile.lock" \
     && echo "gem 'rexml', '3.2.6'" >> "${CONTAINER_APP_ROOT}/app/Gemfile" \
     && su -s /bin/bash -c '${CONTAINER_APP_ROOT}/app/bin/bundle install' "${CONTAINER_APP_USERNAME}"


### PR DESCRIPTION
### Overview

The goal is to load required gems for the discourse-prometheus plugin in case of network issues in production.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
