### PR TITLE
Regroup offline gem installations

### DIFF
--- a/discourse.Dockerfile
+++ b/discourse.Dockerfile
@@ -95,15 +95,15 @@ RUN git clone https://github.com/discourse/discourse-saml.git "${PLUGINS_DIR}/di
     && git clone https://github.com/canonical-web-and-design/discourse-markdown-note.git "${PLUGINS_DIR}/discourse-markdown-note" \
     && git clone https://github.com/unfoldingWord-dev/discourse-mermaid.git "${PLUGINS_DIR}/discourse-mermaid" \
     && git clone https://github.com/discourse/discourse-prometheus.git "${PLUGINS_DIR}/discourse-prometheus" \
+    && mkdir -p "${PLUGINS_DIR}/discourse-saml/gems" \
+    && mkdir -p "${PLUGINS_DIR}/discourse-prometheus/gems" \
     && chown -R "${CONTAINER_APP_USERNAME}:${CONTAINER_APP_GROUP}" "${PLUGINS_DIR}" \
 # Have to determine the gems needed and install them now, otherwise Discourse will
 # try to install them at runtime, which may not work due to network access issues.
     && su -s /bin/bash -c 'gem install bundler' "${CONTAINER_APP_USERNAME}" \
-    && mkdir -p "${PLUGINS_DIR}/discourse-saml/gems" \
     && grep -e ^gem "${PLUGINS_DIR}/discourse-saml/plugin.rb" >> "${PLUGINS_DIR}/discourse-saml/Gemfile" \
     && su -s /bin/bash -c '${CONTAINER_APP_ROOT}/app/bin/bundle install --gemfile=${PLUGINS_DIR}/discourse-saml/Gemfile --path=${PLUGINS_DIR}/discourse-saml/gems' "${CONTAINER_APP_USERNAME}" \
     && ln -s "${PLUGINS_DIR}/discourse-saml/gems/ruby/"* "${PLUGINS_DIR}/discourse-saml/gems/" \
-    && mkdir -p "${PLUGINS_DIR}/discourse-prometheus/gems" \
     && grep -e ^gem "${PLUGINS_DIR}/discourse-prometheus/plugin.rb" >> "${PLUGINS_DIR}/discourse-prometheus/Gemfile" \
     && su -s /bin/bash -c '${CONTAINER_APP_ROOT}/app/bin/bundle install --gemfile=${PLUGINS_DIR}/discourse-prometheus/Gemfile --path=${PLUGINS_DIR}/discourse-prometheus/gems' "${CONTAINER_APP_USERNAME}" \
     && ln -s "${PLUGINS_DIR}/discourse-prometheus/gems/ruby/"* "${PLUGINS_DIR}/discourse-prometheus/gems/" \


### PR DESCRIPTION
### Overview

The goal is to regroup offline gem installations to avoid mistakes and to fix an oversight by adding gems from discourse-prometheus in its `plugin.rb` file.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
