### PR TITLE
Fix charmcraft pack

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,3 +10,7 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
+parts:
+  charm:
+    charm-python-packages: [setuptools, pip]  # https://discourse.charmhub.io/t/install-or-update-python-packages-before-packing-a-charm/5158
+    charm-binary-python-packages: [cosl]  # https://github.com/canonical/charmcraft/issues/1269


### PR DESCRIPTION
### Overview

Fix charmcraft pack by installing some transient dependencies in the builder before the build step.  
Related links:
- https://github.com/pypa/setuptools_scm/issues/918
- https://github.com/canonical/charmcraft/issues/1269
- https://chat.charmhub.io/charmhub/pl/ks6irz8g5tgxiq5xnnty4xu6ww
- https://discourse.charmhub.io/t/install-or-update-python-packages-before-packing-a-charm/5158

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)