### PR TITLE
Force charm service to stop on db relation broken

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -615,4 +615,4 @@ def test_redis_relation_data(relation_data, should_be_ready):
     redis_relation_id = harness.add_relation("redis", "redis")
     harness.add_relation_unit(redis_relation_id, "redis/0")
     harness.charm._stored.redis_relation = {redis_relation_id: relation_data}
-    assert should_be_ready == harness.charm._are_db_relations_ready()
+    assert should_be_ready == harness.charm._are_relations_ready()

--- a/tox.ini
+++ b/tox.ini
@@ -39,26 +39,27 @@ deps =
     bs4
     codespell
     flake8<6.0.0
+    flake8-builtins
+    flake8-copyright
     flake8-docstrings
     flake8-docstrings-complete
-    flake8-copyright
-    flake8-builtins
     flake8-test-docs
     isort
+    juju<3.0
     mypy
     ops>=2.6.0
     ops-lib-pgsql
+    pep8-naming
     psycopg2-binary
     pydocstyle>=2.10
     pylint
     pyproject-flake8<6.0.0
     pytest_asyncio
     pytest_operator
-    pep8-naming
     toml
     types-beautifulsoup4
-    types-PyYAML
     types-psycopg2
+    types-PyYAML
     types-requests
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
### Overview

The charm stayed incorrectly in an active state when the db relation was broken.  
This PR makes sure that the service stops when this is the case.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)