### PR TITLE
Fix app_launch script

### DIFF
--- a/discourse_rock/scripts/app_launch.sh
+++ b/discourse_rock/scripts/app_launch.sh
@@ -6,9 +6,4 @@ export UNICORN_BIND_ALL=0.0.0.0
 export UNICORN_SIDEKIQS=1
 
 cd "$CONTAINER_APP_ROOT/app" || exit
-
-bin/unicorn -c config/unicorn.conf.rb &
-
-# If one of the processes exits, the other one will be killed so that the pod will be restarted by the failing probes
-wait -n
-kill "$(jobs -p)"
+exec bin/unicorn -c config/unicorn.conf.rb


### PR DESCRIPTION
### Overview

It could happen that when restarting the discourse charm service, we were greeted by:
```
2023-09-26T19:30:10.115Z [pebble] Service "discourse" starting: sh -c '/srv/scripts/app_launch.sh'
2023-09-26T19:30:12.049Z [pebble] Check "discourse-check" failure 70 (threshold 3): Get "http://localhost:3000": dial tcp [::1]:3000: connect: connection refused
2023-09-26T19:30:12.884Z [discourse] /srv/scripts/app_launch.sh: line 14: kill: `': not a pid or valid job spec
```

Since we switched to the default prometheus exporter as a discourse plugin, we don't start it as a separate process anymore. The app_launch script was made to accommodate both launches in one script but this is not needed anymore.  
Since we're only launching one job now, I removed the necessity to check for background jobs and simply exec'ed unicorn.  

This error was not catched in our integration test about relating/un-relating dependencies because the status of the charm doesn't depend on the service inside being up. I'll fix that in a subsequent PR.


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)