### PR TITLE
Use the brand new profiles for postgresql-k8s

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -133,7 +133,11 @@ async def app_fixture(
     Builds the charm and deploys it and the relations it depends on.
     """
     postgres_app = await model.deploy(
-        "postgresql-k8s", channel="14/edge", series="jammy", trust=True
+        "postgresql-k8s",
+        channel="14/edge",
+        series="jammy",
+        trust=True,
+        config={"profile": "testing"},
     )
     await model.wait_for_idle(apps=[postgres_app.name], status="active")
 


### PR DESCRIPTION
### Overview

Use the new 'testing' [profile](https://charmhub.io/postgresql-k8s/docs/r-profiles) for postgresql-k8s.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)