### PR TITLE
Add _start_service() method and rework discourse setup

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -134,6 +134,8 @@ class DiscourseCharm(CharmBase):
         Args:
             event: Event triggering the endpoints changed handler.
         """
+        if self.unit.is_leader():
+            self._execute_migrations()
         if self._are_relations_ready():
             self._reload_configuration()
 


### PR DESCRIPTION
### Overview

This is a follow-up to this PR: https://github.com/canonical/discourse-k8s-operator/pull/108  
This fixes multiple things:
- Make sure that the service is restarted when the necessary relations are present (redis and postgres)
- Apply the db migrations when postgres gets related

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

#### Explanations for the checklist
- ISD054 will be addressed in the next cycle
- src-docs will be added in another PR