### PR TITLE
Add --use-existing feature to integ tests

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -492,6 +492,7 @@ class DiscourseCharm(CharmBase):
             return
         env_settings = self._create_discourse_environment_settings()
         try:
+            logger.info("Setting workload version")
             get_version_process = container.exec(
                 [f"{DISCOURSE_PATH}/bin/rails", "runner", "puts Discourse::VERSION::STRING"],
                 environment=env_settings,
@@ -511,6 +512,7 @@ class DiscourseCharm(CharmBase):
         env_settings = self._create_discourse_environment_settings()
         try:
             self.model.unit.status = MaintenanceStatus("Running S3 migration")
+            logger.info("Running S3 migration")
             process = container.exec(
                 [f"{DISCOURSE_PATH}/bin/bundle", "exec", "rake", "s3:upload_assets"],
                 environment=env_settings,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,3 +10,9 @@ def pytest_addoption(parser):
     parser.addoption("--saml-email", action="store")
     parser.addoption("--saml-password", action="store")
     parser.addoption("--charm-file", action="store", default=None)
+    parser.addoption(
+        "--use-existing",
+        action="store_true",
+        default=False,
+        help="This will skip deployment of the charms. Useful for local testing.",
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -132,6 +132,11 @@ async def app_fixture(
     """Discourse charm used for integration testing.
     Builds the charm and deploys it and the relations it depends on.
     """
+    use_existing = pytestconfig.getoption("--use-existing", default=False)
+    if use_existing:
+        yield model.applications[app_name]
+        return
+
     postgres_app = await model.deploy(
         "postgresql-k8s",
         channel="14/edge",


### PR DESCRIPTION
### Overview

Add `--use-existing` option to the integration tests as a quality-of-life change for local testing.  
Also added some logs for the charm initialization tasks.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)