### PR TITLE
Minimal changes to add the data explorer plugin

### DIFF
--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -138,6 +138,15 @@ parts:
       grep -e ^gem plugin.rb >> Gemfile
     organize:
       "*": srv/discourse/app/plugins/discourse-prometheus/
+  get-data-explorer:
+    plugin: dump
+    after:
+      - get-discourse
+   source: https://github.com/discourse/discourse-data-explorer.git
+   source-commit: e7c19ac107dcd37618c7ac7b98530e99c7fe31db
+   source-depth: 1
+   organize:
+     "*": srv/discourse/app/plugins/discourse-data-explorer/
   get-patches:
     plugin: dump
     source: patches
@@ -163,6 +172,7 @@ parts:
       - get-discourse
       - get-saml-plugin-source
       - get-prometheus-plugin-source
+      - get-data-explorer
       - apply-patches
     build-packages:
       - libpq-dev


### PR DESCRIPTION
### Overview
We want to land this "properly" in PR#125, but if we need to land this as quickly as possible this might give us another option. As such this is the minimal set of changes needed to enable the data explorer plugin.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
