### PR TITLE
Add discourse-rad-plugin to the ROCK

### DIFF
--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -91,6 +91,15 @@ parts:
       "*.*": srv/discourse/app/
       "*": srv/discourse/app/
       ".*": srv/discourse/app/
+  get-rad-plugin-source:
+    plugin: dump
+    source: https://github.com/canonical/discourse-rad-plugin.git
+    source-commit: 8612594e1bbbfbba7b9166d09c03b4a7fb4afbe9
+    source-depth: 1
+    after:
+      - get-discourse
+    organize:
+      "*": srv/discourse/app/plugins/discourse-rad-plugin/
   get-solved-plugin-source:
     plugin: dump
     source: https://github.com/discourse/discourse-solved.git
@@ -216,6 +225,7 @@ parts:
       - get-markdown-note-plugin-source
       - get-mermaid-plugin-source
       - get-scripts
+      - get-rad-plugin-source
       - get-solved-plugin-source
       - install-gems
       - install-terser


### PR DESCRIPTION
### Overview

This PR changes the Discourse ROCK by adding a new plugin discourse-rad-plugin to the list making it available to all instances of the charm.

### Rationale

This is required for some discourse-based documentation to render correctly.

### Juju Events Changes

n/a

### Module Changes

n/a

### Library Changes

n/a

### Checklist

- [x ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x ] The documentation is generated using `src-docs`
- [x ] The documentation for charmhub is updated.
- [x ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
