### PR TITLE
Avoid running tests when only docs are changed

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -5,6 +5,9 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'src-docs/**'
+      - 'README.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
 
 jobs:
   integration-tests:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -2,6 +2,9 @@ name: Integration tests
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'src-docs/**'
 
 jobs:
   integration-tests:

--- a/.github/workflows/integration_test_with_secrets.yaml
+++ b/.github/workflows/integration_test_with_secrets.yaml
@@ -2,6 +2,9 @@ name: Integration tests (require secrets)
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'src-docs/**'
 
 jobs:
   integration-tests-with-secrets:

--- a/.github/workflows/integration_test_with_secrets.yaml
+++ b/.github/workflows/integration_test_with_secrets.yaml
@@ -5,6 +5,9 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'src-docs/**'
+      - 'README.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
 
 jobs:
   integration-tests-with-secrets:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,9 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'src-docs/**'
+      - 'README.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
 
 jobs:
   unit-tests:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,9 @@ name: Tests
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'src-docs/**'
 
 jobs:
   unit-tests:

--- a/README.md
+++ b/README.md
@@ -40,5 +40,4 @@ Thinking about using the Discourse Operator for your next project? [Get in touch
 
 ---
 
-For further details,
-[see the charm's detailed documentation](https://charmhub.io/discourse-k8s/docs).
+For further details, [see the charm's detailed documentation](https://charmhub.io/discourse-k8s/docs).


### PR DESCRIPTION
### Overview

Avoid running tests when only docs are changed.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)