### PR TITLE
Make sure to setup discourse on database created event

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -158,9 +158,7 @@ class DiscourseCharm(CharmBase):
         Args:
             event: Event triggering the database created handler.
         """
-        self._execute_migrations()
-        if self._are_relations_ready():
-            self._activate_charm()
+        self._setup_and_activate()
 
     def _on_database_endpoints_changed(self, _: DatabaseEndpointsChangedEvent) -> None:
         """Handle endpoints change.

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -43,10 +43,10 @@ def start_harness(
     harness.handle_exec("discourse", [], result=0)
 
     if with_postgres:
-        _add_postgres_relation(harness)
+        add_postgres_relation(harness)
 
     if with_redis:
-        _add_redis_relation(harness)
+        add_redis_relation(harness)
 
     if with_ingress:
         _add_ingress_relation(harness)
@@ -73,7 +73,7 @@ def _patch_setup_completed():
         yield
 
 
-def _add_postgres_relation(harness):
+def add_postgres_relation(harness):
     """Add postgresql relation and relation data to the charm.
 
     Args:
@@ -101,7 +101,7 @@ def _add_postgres_relation(harness):
     )
 
 
-def _add_redis_relation(harness):
+def add_redis_relation(harness, relation_data=None):
     """Add redis relation and relation data to the charm.
 
     Args:
@@ -115,6 +115,8 @@ def _add_redis_relation(harness):
     # pylint: disable=protected-access
     harness.charm._stored.redis_relation = {
         redis_relation_id: {"hostname": "redis-host", "port": 1010}
+        if relation_data is None
+        else relation_data
     }
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -459,7 +459,7 @@ def test_handle_redis_relation_changed_event():
 
     harness.container_pebble_ready(CONTAINER_NAME)
     plan_before_event = harness.get_container_pebble_plan(CONTAINER_NAME)
-    helpers._add_redis_relation(harness)
+    helpers.add_redis_relation(harness)
     harness.charm.on.redis_relation_updated.emit()
     plan_after_event = harness.get_container_pebble_plan(CONTAINER_NAME)
     assert plan_before_event.__dict__ != plan_after_event.__dict__
@@ -648,7 +648,17 @@ def test_is_redis_relation_ready(relation_data, should_be_ready):
     assert: the charm should wait for some correct relation data
     """
     harness = helpers.start_harness(with_postgres=True, with_redis=False)
-    redis_relation_id = harness.add_relation("redis", "redis")
-    harness.add_relation_unit(redis_relation_id, "redis/0")
-    harness.charm._stored.redis_relation = {redis_relation_id: relation_data}
+    helpers.add_redis_relation(harness, relation_data)
     assert should_be_ready == harness.charm._are_relations_ready()
+
+
+def test_relate_database_at_the_end():
+    """
+    arrange: given a deployed discourse charm with redis related
+    act: relate the database after the pebble ready event
+    assert: it should activate the charm
+    """
+    harness = helpers.start_harness(with_postgres=False, with_redis=True)
+    harness.container_pebble_ready("discourse")
+    helpers.add_postgres_relation(harness)
+    assert harness.model.unit.status == ActiveStatus()


### PR DESCRIPTION
### Overview

Make sure to setup discourse on database created event

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)