### PR TITLE
Add proxy juju env support

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -414,6 +414,17 @@ class DiscourseCharm(CharmBase):
         # self.config return an Any type
         pod_config.update(THROTTLE_LEVELS.get(self.config["throttle_level"]))  # type: ignore
 
+        # Update environment with proxy settings
+        pod_config["HTTP_PROXY"] = pod_config["http_proxy"] = (
+            os.environ.get("JUJU_CHARM_HTTP_PROXY") or ""
+        )
+        pod_config["HTTPS_PROXY"] = pod_config["https_proxy"] = (
+            os.environ.get("JUJU_CHARM_HTTPS_PROXY") or ""
+        )
+        pod_config["NO_PROXY"] = pod_config["no_proxy"] = (
+            os.environ.get("JUJU_CHARM_NO_PROXY") or ""
+        )
+
         return pod_config
 
     def _create_layer_config(self) -> ops.pebble.LayerDict:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -662,3 +662,32 @@ def test_relate_database_at_the_end():
     harness.container_pebble_ready("discourse")
     helpers.add_postgres_relation(harness)
     assert harness.model.unit.status == ActiveStatus()
+
+
+def test_http_proxy_env(monkeypatch):
+    """
+    arrange: given a deployed discourse charm with all the required relations
+    act: when a juju http_proxy variable is changed
+    assert: the appropriate configuration values should be present in the created env
+    """
+    harness = helpers.start_harness()
+
+    created_env = harness._charm._create_discourse_environment_settings()
+    assert created_env["HTTP_PROXY"] == ""
+    assert created_env["http_proxy"] == ""
+    assert created_env["HTTPS_PROXY"] == ""
+    assert created_env["https_proxy"] == ""
+    assert created_env["NO_PROXY"] == ""
+    assert created_env["no_proxy"] == ""
+
+    monkeypatch.setenv("JUJU_CHARM_HTTP_PROXY", "http://proxy.test")
+    monkeypatch.setenv("JUJU_CHARM_HTTPS_PROXY", "http://httpsproxy.test")
+    monkeypatch.setenv("JUJU_CHARM_NO_PROXY", "noproxy.test")
+    created_env = harness._charm._create_discourse_environment_settings()
+
+    assert created_env["HTTP_PROXY"] == "http://proxy.test"
+    assert created_env["http_proxy"] == "http://proxy.test"
+    assert created_env["HTTPS_PROXY"] == "http://httpsproxy.test"
+    assert created_env["https_proxy"] == "http://httpsproxy.test"
+    assert created_env["NO_PROXY"] == "noproxy.test"
+    assert created_env["no_proxy"] == "noproxy.test"


### PR DESCRIPTION
### Overview

Add support for juju-http(s)-proxy model-config settings.  
This populates the http_proxy, no_proxy environment variables for all pebble operations.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)