### PR TITLE
fix(ci): Pin protobuf

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -113,6 +113,7 @@ deps =
     bs4
     cosl
     juju>=3.0
+    protobuf==3.20.3
     pytest
     pytest-operator
     pytest-asyncio


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Pin protobuf to a sensible version that makes juju>=3.0 and py-macaroon-bakery happy, so we don't end up with failing integration tests due to not being able to resolve the dependency version of protobuf.

### Rationale

Make CI happy.

### Juju Events Changes

n/a

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
n/a

### Library Changes

n/a

### Checklist

- [x ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x ] The documentation is generated using `src-docs`
- [x ] The documentation for charmhub is updated.
- [x ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
