### PR TITLE
Fix/Update plugins

### DIFF
--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -39,10 +39,10 @@ parts:
     build-environment:
       - ARCH: "x64"
       - NODE_VERSION: "18.18.2"
-      - YARN_VERSION: "1.22.19"
-      - RUBY_VERSION: "3.2.2"
-      - RUBY_INSTALL_VERSION: "0.9.2"
       - RAILS_ENV: "production"
+      - RUBY_INSTALL_VERSION: "0.9.2"
+      - RUBY_VERSION: "3.2.2"
+      - YARN_VERSION: "1.22.19"
     override-build: |
       node_uri="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.gz"
       curl -Ls $node_uri | tar xzf - -C $CRAFT_OVERLAY/ --skip-old-files --no-same-owner --strip-components=1
@@ -66,18 +66,14 @@ parts:
     source-type: git
     override-build: |
       craftctl default
-      mkdir -p tmp/backups/default
+      mkdir -p log/production.log
       mkdir -p public/backups/default
       mkdir -p public/uploads/default
-      mkdir -p log/production.log
       mkdir -p srv/discourse/app/bin
       mkdir -p srv/discourse/app/vendor/bundle
+      mkdir -p tmp/backups/default
       touch log/production.log
       touch log/unicorn-stderr.log
-      # rexml version is forced to avoid conflicting transient dependency issue
-      sed -i 's/rexml (3.2.5)/rexml (3.2.6)/' Gemfile.lock
-      # The following is a fix for https://github.com/discourse/discourse-prometheus/blob/72fff206ba18ad5ca3112fed2f5f0ce6a17ca6f8/plugin.rb#L13C1-L13C105
-      sed -i "s/gem 'prometheus_exporter', .*/gem 'prometheus_exporter', '0.5.0'/g" Gemfile
     organize:
       "*.*": srv/discourse/app/
       "*": srv/discourse/app/
@@ -100,7 +96,7 @@ parts:
     plugin: dump
     after: [discourse, bundler-config]
     source: https://github.com/discourse/discourse-solved.git
-    source-commit: ad1b7c9608bf32c3a991580347302a071d5902d9
+    source-commit: b5d487d6a5bfe2571d936eec5911d02a5f3fcc32
     source-depth: 1
     organize:
       "*": srv/discourse/app/plugins/discourse-solved/
@@ -112,19 +108,19 @@ parts:
     source-depth: 1
     organize:
       "*": srv/discourse/app/plugins/markdown-note/
-  discourse-mermaid:
+  discourse-mermaid-theme-component:
     plugin: dump
     after: [discourse, bundler-config]
-    source: https://github.com/unfoldingWord-dev/discourse-mermaid.git
-    source-commit: 341e1b08608ed0262bae6dffded2eddfae91f67a
+    source: https://github.com/discourse/discourse-mermaid-theme-component.git
+    source-commit: 7ea5abd0ba7bc19f61a9123302f7fc200ce93968
     source-depth: 1
     organize:
-      "*": srv/discourse/app/plugins/discourse-mermaid/
+      "*": srv/discourse/app/plugins/discourse-mermaid-theme-component/
   discourse-saml:
     plugin: dump
     after: [discourse, bundler-config]
     source: https://github.com/discourse/discourse-saml.git
-    source-commit: a23ebee62e11cda87dea81ef8959bc2efd3061a5
+    source-commit: 15a8274bbec438768fb020d4f20462db476b0f29
     source-depth: 1
     override-build: |
       craftctl default
@@ -135,7 +131,7 @@ parts:
     plugin: dump
     after: [discourse, bundler-config]
     source: https://github.com/discourse/discourse-prometheus.git
-    source-commit: 639b8936ca20758802284a35e2b5e764e0a032f9
+    source-commit: 8a7a46a80cc65aa0839bc5e3c3b6f8ef6544089f
     source-depth: 1
     override-build: |
       craftctl default
@@ -146,7 +142,7 @@ parts:
     plugin: dump
     after: [discourse, bundler-config]
     source: https://github.com/discourse/discourse-data-explorer.git
-    source-commit: 840caa39877f0776cd37dc72687d81f5135caa6d
+    source-commit: e4f8d3924a18b303c2bb7da9472cf0c060060e4e
     source-depth: 1
     organize:
       "*": srv/discourse/app/plugins/discourse-data-explorer/
@@ -162,7 +158,7 @@ parts:
     plugin: dump
     after: [discourse, bundler-config]
     source: https://github.com/discourse/discourse-calendar.git
-    source-commit: 7f603a44be44a4f7b237f3813be583958cbf4946
+    source-commit: 6c659020ab5cca4af846b4b78e4ed0b4e06a2bca
     source-depth: 1
     organize:
       "*": srv/discourse/app/plugins/discourse-calendar/
@@ -203,13 +199,16 @@ parts:
       - apply-patches
       - bundler-config
       - discourse
+      - discourse-calendar
       - discourse-data-explorer
+      - discourse-gamification
       - discourse-markdown-note
-      - discourse-mermaid
+      - discourse-mermaid-theme-component
       - discourse-prometheus
       - discourse-rad-plugin
       - discourse-saml
       - discourse-solved
+      - discourse-templates
       - patches
       - scripts
       - tooling
@@ -221,28 +220,28 @@ parts:
       cd srv/discourse/app
       gem install -n "bin" bundler -v 2.4.13
       bin/bundle install
-      bin/bundle install --gemfile="plugins/discourse-saml/Gemfile"
+      bin/bundle install --gemfile="plugins/discourse-calendar/Gemfile"
       bin/bundle install --gemfile="plugins/discourse-data-explorer/Gemfile"
+      bin/bundle install --gemfile="plugins/discourse-gamification/Gemfile"
       bin/bundle install --gemfile="plugins/discourse-prometheus/Gemfile"
+      bin/bundle install --gemfile="plugins/discourse-saml/Gemfile"
       bin/bundle install --gemfile="plugins/discourse-solved/Gemfile"
       bin/bundle install --gemfile="plugins/discourse-templates/Gemfile"
-      bin/bundle install --gemfile="plugins/discourse-calendar/Gemfile"
-      bin/bundle install --gemfile="plugins/discourse-gamification/Gemfile"
       yarn install --immutable
   perms:
     plugin: nil
     after: [tooling, discourse, setup]
     override-prime: |
       chown -R 584792:584792 srv/discourse
-      mkdir -p var/lib/pebble/default/.npm
       mkdir -p var/lib/pebble/default/.cache
       mkdir -p var/lib/pebble/default/.config
       mkdir -p var/lib/pebble/default/.local
+      mkdir -p var/lib/pebble/default/.npm
       mkdir -p var/lib/pebble/default/.yarn
       touch var/lib/pebble/default/.yarnrc
-      chown -R 584792:584792 var/lib/pebble/default/.npm
       chown -R 584792:584792 var/lib/pebble/default/.cache
       chown -R 584792:584792 var/lib/pebble/default/.config
       chown -R 584792:584792 var/lib/pebble/default/.local
+      chown -R 584792:584792 var/lib/pebble/default/.npm
       chown -R 584792:584792 var/lib/pebble/default/.yarn
       chown    584792:584792 var/lib/pebble/default/.yarnrc

--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -66,7 +66,7 @@ parts:
     source-type: git
     override-build: |
       craftctl default
-      mkdir -p log/production.log
+      mkdir -p log
       mkdir -p public/backups/default
       mkdir -p public/uploads/default
       mkdir -p srv/discourse/app/bin


### PR DESCRIPTION
### Overview

- sorted some lists of instructions/variables
- fixed the commit for all the plugins to target the latest compatible with our discourse version
- switch the mermaid plugin to the official one
- add a missing dependency for the `setup` step on the `discourse-calendar` step
- remove some unnecessary patches

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
