### PR TITLE
fix(perms): Run unicorn as non-root user

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -439,7 +439,8 @@ class DiscourseCharm(CharmBase):
                 SERVICE_NAME: {
                     "override": "replace",
                     "summary": "Discourse web application",
-                    "command": f"sh -u _daemon_ -c '{SCRIPT_PATH}/app_launch.sh'",
+                    "command": f"{SCRIPT_PATH}/app_launch.sh",
+                    "user": "_daemon_",
                     "startup": "enabled",
                     "environment": self._create_discourse_environment_settings(),
                 }

--- a/src/charm.py
+++ b/src/charm.py
@@ -439,7 +439,7 @@ class DiscourseCharm(CharmBase):
                 SERVICE_NAME: {
                     "override": "replace",
                     "summary": "Discourse web application",
-                    "command": f"sh -c '{SCRIPT_PATH}/app_launch.sh'",
+                    "command": f"sh -u _daemon_ -c '{SCRIPT_PATH}/app_launch.sh'",
                     "startup": "enabled",
                     "environment": self._create_discourse_environment_settings(),
                 }


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Runs unicorn process as non-root.

### Rationale

It is not expected that the process runs as root, it operates under /srv/discourse/app that is not root owned and operations with .git folder are failing (error: "git detected dubious ownership in repository").

### Juju Events Changes

n/a

### Module Changes

Pebble service has the `_daemon_` user added to the command.

### Library Changes

n/a

### Checklist

- [x ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x ] The documentation is generated using `src-docs`
- [x ] The documentation for charmhub is updated.
- [x ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
