### PR TITLE
Fix commit of discourse-templates plugin (& other fixes)

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 add-admin-user:
   description: Add a new admin user.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 # Learn more about charmcraft.yaml configuration at:
 # https://juju.is/docs/sdk/charmcraft-config

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 options:
   cors_origin:

--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -150,7 +150,7 @@ parts:
     plugin: dump
     after: [discourse, bundler-config]
     source: https://github.com/discourse/discourse-templates.git
-    source-commit: 8ed018fdff6bb2840552c1a1f7313173b7c4c2fc
+    source-commit: f5f4113876c5c7e6bdc291af266c6576659b2cab
     source-depth: 1
     organize:
       "*": srv/discourse/app/plugins/discourse-templates/
@@ -218,7 +218,7 @@ parts:
       - libssl-dev
     override-prime: |
       cd srv/discourse/app
-      gem install -n "bin" bundler -v 2.4.13
+      gem install -n "bin" bundler -v 2.5.3
       bin/bundle install
       bin/bundle install --gemfile="plugins/discourse-calendar/Gemfile"
       bin/bundle install --gemfile="plugins/discourse-data-explorer/Gemfile"
@@ -233,6 +233,7 @@ parts:
     after: [tooling, discourse, setup]
     override-prime: |
       chown -R 584792:584792 srv/discourse
+      chown -R 584792:584792 srv/scripts
       mkdir -p var/lib/pebble/default/.cache
       mkdir -p var/lib/pebble/default/.config
       mkdir -p var/lib/pebble/default/.local

--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: discourse

--- a/discourse_rock/scripts/app_launch.sh
+++ b/discourse_rock/scripts/app_launch.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 export UNICORN_BIND_ALL=0.0.0.0

--- a/generate-src-docs.sh
+++ b/generate-src-docs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 rm -rf src-docs

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
+++ b/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # Licensed under the Apache2.0. See LICENSE file in charm source for details.
 """Library for the nginx-route relation.
 

--- a/localstack-installation.sh
+++ b/localstack-installation.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 pip install pip --upgrade

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 name: discourse-k8s
 display-name: Discourse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tool.bandit]

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Charm for Discourse on kubernetes."""

--- a/src/database.py
+++ b/src/database.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Provide the DatabaseObserver class to handle database relation and state."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 """Module for test customizations."""
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 """Discourse integration tests fixtures."""
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 """Discourse integration tests."""
 

--- a/tests/integration/types.py
+++ b/tests/integration/types.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Useful types for integration tests."""

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """helpers for the unit tests."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Unit tests for Discourse charm."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]


### PR DESCRIPTION
### Overview

This fixes the commit used for the discourse-templates plugin (the previous selected commit was not compatible with the selected version of discourse).  
Some additional minor changes:
- Added a CONTAINER_APP_USERNAME global variable in charm.py
- Updated bundler gem version
- Fix the ownership of the scripts directory

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
