### PR TITLE
feat(replies): Reply via pop3 polling

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -134,3 +134,27 @@ options:
     type: boolean
     description: Configure Discourse to use https.
     default: false
+  reply_by_email_address:
+    type: string
+    description: Replies email in the form of replies+%{reply_key}@example.com.
+    default: ""
+  pop3_polling_username:
+    type: string
+    description: Username of the email account like replies@example.com.
+    default: ""
+  pop3_polling_password:
+    type: string
+    description: The password of that email account.
+    default: ""
+  pop3_polling_host:
+    type: string
+    description: Polling host such as pop.gmail.com.
+    default: ""
+  pop3_polling_enabled:
+    type: boolean
+    description: Whether pop3 polling is enabled.
+    default: false
+  reply_by_email_enabled:
+    type: boolean
+    description: Whether replying by email is enabled.
+    default: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -401,6 +401,12 @@ class DiscourseCharm(CharmBase):
             "DISCOURSE_SMTP_PASSWORD": self.config["smtp_password"],
             "DISCOURSE_SMTP_PORT": str(self.config["smtp_port"]),
             "DISCOURSE_SMTP_USER_NAME": self.config["smtp_username"],
+            "DISCOURSE_POP3_POLLING_HOST": self.config["pop3_polling_host"],
+            "DISCOURSE_POP3_POLLING_USERNAME": self.config["pop3_polling_username"],
+            "DISCOURSE_POP3_POLLING_PASSWORD": self.config["pop3_polling_password"],
+            "DISCOURSE_POP3_POLLING_ENABLED": str(self.config["pop3_polling_enabled"]).lower(),
+            "DISCOURSE_REPLY_BY_EMAIL_ADDRESS": self.config["reply_by_email_address"],
+            "DISCOURSE_REPLY_BY_EMAIL_ENABLED": str(self.config["reply_by_email_enabled"]).lower(),
             "RAILS_ENV": "production",
         }
         pod_config.update(self._get_saml_config())


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

Note: this PR works in theory and does not currently ship with an integration test - reason being to test this, you need two mail servers (receiving mail into Discourse, configured server with pop3 enabled, sending mails to Discourse) and a mechanism to respond to a thread via e-mail and ensure it is received. Overall a painful and tricky business. Proposal is to test this manually.

Second note: if already configured via GUI, the changes can/will get overwritten when moving to env variables, that is by design, see [here](https://meta.discourse.org/t/s3-backup-bucket-option-missing-from-settings-backups/224802).

### Overview

<!-- A high level overview of the change -->

This PR adds the capability to enable replies to threads via pop3 polling as described [here](https://meta.discourse.org/t/set-up-reply-by-email-with-pop3-polling/14003) via `juju config` on the parameters.

### Rationale

<!-- The reason the change is needed -->

This capability is available via GUI and it was requested that it is available as a config as well.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
none

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

Adds new pop3 parameters to `config.yaml` and sets these as env variables to feed to pebble in `src/charm.py`.


### Library Changes

<!-- Any changes to charm libraries -->
none

### Checklist

- [x ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x ] The documentation is generated using `src-docs`
- [x ] The documentation for charmhub is updated.
- [x ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
