### PR TITLE
fix(postgresql): Add pg_dump

### DIFF
--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -32,6 +32,7 @@ parts:
       - libz-dev
       - optipng
       - pngquant
+      - postgresql-client
       - redis-tools
       - tzdata
       - ubuntu-dev-tools

--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -32,7 +32,7 @@ parts:
       - libz-dev
       - optipng
       - pngquant
-      - postgresql-client
+      - postgresql-client-common
       - redis-tools
       - tzdata
       - ubuntu-dev-tools


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->

Adds pg_dump so Discourse backups don't fail.

### Rationale

<!-- The reason the change is needed -->

Discourse backups fail now due to missing pg_dump,

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

n/a

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
n/a

### Library Changes

<!-- Any changes to charm libraries -->
n/a

### Checklist

- [x ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x ] The documentation is generated using `src-docs`
- [x ] The documentation for charmhub is updated.
- [x ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
