### PR TITLE
Fix/add pg dump

### DIFF
--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -5,6 +5,7 @@ name: discourse
 summary: Discourse rock
 description: Discourse OCI image for the Discourse charm
 base: ubuntu@22.04
+# renovate: base: ubuntu:22.04@sha256:8eab65df33a6de2844c9aefd19efe8ddb87b7df5e9185a4ab73af936225685bb
 run-user: _daemon_  # UID/GID 584792
 license: Apache-2.0
 version: "1.0"

--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -32,6 +32,7 @@ parts:
       - libz-dev
       - optipng
       - pngquant
+      - postgresql-client
       - redis-tools
       - tzdata
       - ubuntu-dev-tools

--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -32,7 +32,7 @@ parts:
       - libz-dev
       - optipng
       - pngquant
-      - postgresql-client
+      - postgresql-client-common
       - redis-tools
       - tzdata
       - ubuntu-dev-tools

--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -32,6 +32,7 @@ parts:
       - libz-dev
       - optipng
       - pngquant
+      - postgresql-client
       - postgresql-client-common
       - redis-tools
       - tzdata


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

adds a client pg_dump next to the wrapper (that expects a client...go figure)

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->
pg_dump wrapper will not work unless there is a client installed next to it

I also added an annotation for the base image for renovate while were at it..

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
n/a
### Module Changes
n/a
<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes
n/a
<!-- Any changes to charm libraries -->

### Checklist

- [ x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x ] The documentation is generated using `src-docs`
- [ x] The documentation for charmhub is updated.
- [ x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
