### PR TITLE
chore(discourse): Bump to v3.1.4

### DIFF
--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -123,7 +123,7 @@ parts:
     plugin: dump
     after: [discourse, bundler-config]
     source: https://github.com/discourse/discourse-saml.git
-    source-commit: 15a8274bbec438768fb020d4f20462db476b0f29
+    source-commit: a23ebee62e11cda87dea81ef8959bc2efd3061a5
     source-depth: 1
     override-build: |
       craftctl default

--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -65,7 +65,7 @@ parts:
     plugin: dump
     source: https://github.com/discourse/discourse.git
     source-depth: 1
-    source-tag: v3.1.3
+    source-tag: v3.1.4
     source-type: git
     override-build: |
       craftctl default


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->

Bumping to Discourse v3.1.4

### Rationale

<!-- The reason the change is needed -->
v3.1.4 available, bumping from v3.1.3 to v3.1.4

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
n/a

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
n/a

### Library Changes

<!-- Any changes to charm libraries -->
n/a

### Checklist

- [x ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x ] The documentation is generated using `src-docs`
- [x ] The documentation for charmhub is updated.
- [x ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
