### PR TITLE
Add Rails console docs

### DIFF
--- a/docs/how-to/access--the-rails-console.md
+++ b/docs/how-to/access--the-rails-console.md
@@ -17,11 +17,7 @@ Then ssh into the Discourse unit:
 ```
 juju ssh --container discourse discourse-k8s/leader bash   
 ```
-Now populate the required environment variables:
-```
-xargs -0 -L1 -a "/proc/$(ps aux | awk '/[a]pp_launch/ {print $2;exit}')/environ" | awk '{FS="=";print "export " $1 "=\"" $2 "\""}' > /root/envi && . /root/envi && rm /root/envi
-```
-In newer versions of the charm (revision 70+), the command to execute is the following:
+Now populate the required environment variables, this requires charm revision 70 or greater:
 ```
 sudo -u _daemon_ xargs -0 -L1 -a "/proc/$(ps aux | awk '/[u]nicorn master/ {print $2;exit}')/environ" | awk '{FS="=";print "export " $1 "=\"" $2 "\""}' > /root/envi && . /root/envi && rm /root/envi
 ```

--- a/docs/how-to/access--the-rails-console.md
+++ b/docs/how-to/access--the-rails-console.md
@@ -21,7 +21,7 @@ Now populate the required environment variables:
 ```
 xargs -0 -L1 -a "/proc/$(ps aux | awk '/[a]pp_launch/ {print $2;exit}')/environ" | awk '{FS="=";print "export " $1 "=\"" $2 "\""}' > /root/envi && . /root/envi && rm /root/envi
 ```
-In newer versions of the charm (revision 70+), the command to execute is the following instead:
+In newer versions of the charm (revision 70+), the command to execute is the following:
 ```
 sudo -u _daemon_ xargs -0 -L1 -a "/proc/$(ps aux | awk '/[u]nicorn master/ {print $2;exit}')/environ" | awk '{FS="=";print "export " $1 "=\"" $2 "\""}' > /root/envi && . /root/envi && rm /root/envi
 ```

--- a/docs/how-to/access--the-rails-console.md
+++ b/docs/how-to/access--the-rails-console.md
@@ -1,0 +1,38 @@
+# How to access the Rails console
+
+Ideally, the discourse charm should be handled by interacting with Juju, and everything that can be done with the console should
+be doable with juju actions. In case there is something that needs to be done with the console anyway, the console can be accessed.
+
+### Prerequisites
+
+Have a Discourse deployment active.
+
+### Access the console
+
+First of all, switch into the juju Discourse model if necessary:
+```
+juju switch discourse-model
+```
+Then ssh into the Discourse unit:
+```
+juju ssh --container discourse discourse-k8s/leader bash   
+```
+Now populate the required environment variables:
+```
+xargs -0 -L1 -a "/proc/$(ps aux | awk '/[a]pp_launch/ {print $2;exit}')/environ" | awk '{FS="=";print "export " $1 "=\"" $2 "\""}' > /root/envi && . /root/envi && rm /root/envi
+```
+In newer versions of the charm (revision 70+), the command to execute is the following instead:
+```
+sudo -u _daemon_ xargs -0 -L1 -a "/proc/$(ps aux | awk '/[u]nicorn master/ {print $2;exit}')/environ" | awk '{FS="=";print "export " $1 "=\"" $2 "\""}' > /root/envi && . /root/envi && rm /root/envi
+```
+Now change to the appropiate directory and execute the command to access the console:
+```
+cd /srv/discourse/app
+RAILS_ENV=production bin/bundle exec rails console
+```
+If the output of the last command contains something similar to this:
+```
+Loading production environment (Rails 7.0.5.1)
+irb(main):001:0>
+```
+Congratulations, you have accessed the rails console.

--- a/docs/how-to/access--the-rails-console.md
+++ b/docs/how-to/access--the-rails-console.md
@@ -25,7 +25,7 @@ In newer versions of the charm (revision 70+), the command to execute is the fol
 ```
 sudo -u _daemon_ xargs -0 -L1 -a "/proc/$(ps aux | awk '/[u]nicorn master/ {print $2;exit}')/environ" | awk '{FS="=";print "export " $1 "=\"" $2 "\""}' > /root/envi && . /root/envi && rm /root/envi
 ```
-Now change to the appropiate directory and execute the command to access the console:
+Now change to the appropriate directory and execute the command to access the console:
 ```
 cd /srv/discourse/app
 RAILS_ENV=production bin/bundle exec rails console


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Add documentation regarding how to access a rails console.

### Rationale

Sometimes it might be necessary for the operator to access a console in order to perform actions not yet contemplated by juju actions

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

Once the PR gets approved, the documentation in charmhub will be updated accordingly before merging.
