### PR TITLE
Add an unused event handler as arg to _setup_and_activate to satisfy rollingops

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -193,8 +193,12 @@ class DiscourseCharm(CharmBase):
         """
         self._configure_pod()
 
-    def _setup_and_activate(self) -> None:
-        """Set up discourse, configure the pod and eventually activate the charm."""
+    def _setup_and_activate(self, _: HookEvent) -> None:
+        """Set up discourse, configure the pod and eventually activate the charm.
+
+        Args:
+            event: Event triggering the setup and activate handler.
+        """
         if not self._is_setup_completed():
             self._set_up_discourse()
         self._configure_pod()

--- a/src/charm.py
+++ b/src/charm.py
@@ -193,7 +193,7 @@ class DiscourseCharm(CharmBase):
         """
         self._configure_pod()
 
-    def _setup_and_activate(self, _: HookEvent) -> None:
+    def _setup_and_activate(self, _: HookEvent | None = None) -> None:
         """Set up discourse, configure the pod and eventually activate the charm.
 
         Args:


### PR DESCRIPTION
### Overview

Add an unused event handler as an argument to _setup_and_activate, which is the callback to the rollingops library, as it will pass this as an argument.

### Rationale

When deploying on staging we observed the following:
```
  File "/var/lib/juju/agents/unit-stg-discourse-k8s-1/charm/lib/charms/rolling_o
ps/v0/rollingops.py", line 335, in _on_relation_changed
    self.charm.on[self.name].run_with_lock.emit()
  File "/var/lib/juju/agents/unit-stg-discourse-k8s-1/charm/venv/ops/framework.p
y", line 351, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-stg-discourse-k8s-1/charm/venv/ops/framework.p
y", line 853, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-stg-discourse-k8s-1/charm/venv/ops/framework.p
y", line 942, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-stg-discourse-k8s-1/charm/lib/charms/rolling_o
ps/v0/rollingops.py", line 404, in _on_run_with_lock
    callback(event)
TypeError: _setup_and_activate() takes 1 positional argument but 2 were given
```

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
