### PR TITLE
fix(update): Wrap rolling callback

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -31,7 +31,7 @@ juju config postgresql-k8s plugin_pg_trgm_enable=True
 
 # Relate redis-k8s and postgresql-k8s to discourse-k8s
 juju relate redis-k8s discourse-k8s
-juju relate discourse-k8s postgresql-k8s:db
+juju relate discourse-k8s postgresql-k8s
 
 ```
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -123,7 +123,7 @@ class DiscourseCharm(CharmBase):
         self._grafana_dashboards = GrafanaDashboardProvider(self)
 
         self.restart_manager = RollingOpsManager(
-            charm=self, relation="restart", callback=self._setup_and_activate
+            charm=self, relation="restart", callback=self._on_rolling_update
         )
 
     def _on_start(self, _: ops.StartEvent) -> None:
@@ -192,6 +192,14 @@ class DiscourseCharm(CharmBase):
             event: Event triggering the config change handler.
         """
         self._configure_pod()
+
+    def _on_rolling_update(self, _: HookEvent) -> None:
+        """Handle rolling updates.
+
+        Args:
+            event: Event triggering the config change handler.
+        """
+        self._setup_and_activate()
 
     def _setup_and_activate(self) -> None:
         """Set up discourse, configure the pod and eventually activate the charm."""


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Wraps the rolling ops callback in a hook function that calls the underlying `_setup_and_activate` like it is called with other hooks.

### Rationale

<!-- The reason the change is needed -->

Rolling ops adds the event to the callback so an event is needed.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
n/a

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
adds wrapper function

### Library Changes

<!-- Any changes to charm libraries -->
n/a

### Checklist

- [x ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x ] The documentation is generated using `src-docs`
- [x ] The documentation for charmhub is updated.
- [x ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
