### PR TITLE
Fix rolling restart by adding a dedicated callback method

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -123,7 +123,7 @@ class DiscourseCharm(CharmBase):
         self._grafana_dashboards = GrafanaDashboardProvider(self)
 
         self.restart_manager = RollingOpsManager(
-            charm=self, relation="restart", callback=self._setup_and_activate
+            charm=self, relation="restart", callback=self._on_rolling_restart
         )
 
     def _on_start(self, _: ops.StartEvent) -> None:
@@ -192,6 +192,14 @@ class DiscourseCharm(CharmBase):
             event: Event triggering the config change handler.
         """
         self._configure_pod()
+
+    def _on_rolling_restart(self, _: ops.EventBase) -> None:
+        """Handle rolling restart event.
+
+        Args:
+            event: Event triggering the discourse rolling restart event handler.
+        """
+        self._setup_and_activate()
 
     def _setup_and_activate(self) -> None:
         """Set up discourse, configure the pod and eventually activate the charm."""


### PR DESCRIPTION
### Overview

Add handler method for rolling restart to be used as callback method for the RollingOpsManager.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
