### PR TITLE
Remove chaos variables from integration tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,11 +8,6 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      chaos-app-label: app.kubernetes.io/name=discourse-k8s
-      chaos-duration: 600
-      chaos-enabled: false
-      chaos-experiments: pod-delete
-      chaos-status-duration: 300
       extra-arguments: --localstack-address 172.17.0.1 -m "not (requires_secrets)"
       pre-run-script: localstack-installation.sh
       trivy-image-config: "trivy.yaml"

--- a/.github/workflows/integration_test_with_secrets.yaml
+++ b/.github/workflows/integration_test_with_secrets.yaml
@@ -8,11 +8,6 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      chaos-app-label: app.kubernetes.io/name=discourse-k8s
-      chaos-duration: 600
-      chaos-enabled: false
-      chaos-experiments: pod-delete
-      chaos-status-duration: 300
       extra-arguments: --localstack-address 172.17.0.1 -m "requires_secrets"
       pre-run-script: localstack-installation.sh
       trivy-image-config: "trivy.yaml"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->
Remove `chaos-*` variables from integration tests as they were removed from https://github.com/canonical/operator-workflows/pull/254.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
