### PR TITLE
ISD-1516 Remove is_leader check when running db migration

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -534,20 +534,19 @@ class DiscourseCharm(CharmBase):
         if not self._are_relations_ready() or not container.can_connect():
             logger.info("Not ready to execute migrations")
             return
-        if self.model.unit.is_leader():
-            env_settings = self._create_discourse_environment_settings()
-            self.model.unit.status = MaintenanceStatus("Executing migrations")
-            try:
-                migration_process: ExecProcess = container.exec(
-                    [f"{DISCOURSE_PATH}/bin/bundle", "exec", "rake", "--trace", "db:migrate"],
-                    environment=env_settings,
-                    working_dir=DISCOURSE_PATH,
-                    user=CONTAINER_APP_USERNAME,
-                )
-                migration_process.wait_output()
-            except ExecError as cmd_err:
-                logger.exception("Executing migrations failed with code %d.", cmd_err.exit_code)
-                raise
+        env_settings = self._create_discourse_environment_settings()
+        self.model.unit.status = MaintenanceStatus("Executing migrations")
+        try:
+            migration_process: ExecProcess = container.exec(
+                [f"{DISCOURSE_PATH}/bin/bundle", "exec", "rake", "--trace", "db:migrate"],
+                environment=env_settings,
+                working_dir=DISCOURSE_PATH,
+                user=CONTAINER_APP_USERNAME,
+            )
+            migration_process.wait_output()
+        except ExecError as cmd_err:
+            logger.exception("Executing migrations failed with code %d.", cmd_err.exit_code)
+            raise
 
     def _compile_assets(self) -> None:
         container = self.unit.get_container(CONTAINER_NAME)

--- a/src/charm.py
+++ b/src/charm.py
@@ -536,6 +536,11 @@ class DiscourseCharm(CharmBase):
             return
         env_settings = self._create_discourse_environment_settings()
         self.model.unit.status = MaintenanceStatus("Executing migrations")
+        # The rails migration task is idempotent and concurrent-safe, from
+        # https://stackoverflow.com/questions/17815769/are-rake-dbcreate-and-rake-dbmigrate-idempotent
+        # and https://github.com/rails/rails/pull/22122
+        # Thus it's safe to run this task on all units to
+        # avoid complications with how juju schedules charm upgrades
         try:
             migration_process: ExecProcess = container.exec(
                 [f"{DISCOURSE_PATH}/bin/bundle", "exec", "rake", "--trace", "db:migrate"],


### PR DESCRIPTION
We can take advantage of the idem-potency of the `db:migrate` task to remove a check and run that task on all units.

Local tests shows a time loss of around 3s per unit for each skipped checks (note that unit-discourse-k8s-1 is doing the actual migration and the other calling the task and skipping it):
```
unit-discourse-k8s-1: 00:34:47 INFO unit.discourse-k8s/1.juju-log Discourse setup: about to execute migrations
unit-discourse-k8s-1: 00:34:51 INFO unit.discourse-k8s/1.juju-log unit: <ops.model.Unit discourse-k8s/1> DB migration done in 4.5590386390686035 seconds
...
unit-discourse-k8s-0: 00:37:36 INFO unit.discourse-k8s/0.juju-log unit: <ops.model.Unit discourse-k8s/0> DB migration done in 3.47281813621521 seconds
unit-discourse-k8s-0: 00:37:36 INFO unit.discourse-k8s/0.juju-log Discourse setup: about to compile assets
```

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
