### PR TITLE
Add smtp_force_tls and smtp_enable_start_tls config options

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,11 +43,11 @@ options:
     default: ""
   smtp_enable_start_tls:
     type: string
-    description: "enable TLS encryption for smtp connections"
+    description: "Enable TLS encryption for smtp connections."
     default: "true"
   smtp_force_tls:
     type: string
-    description: "force implicit TLS as per RFC 8314 3.3"
+    description: "Force implicit TLS as per RFC 8314 3.3."
     default: "false"
   smtp_openssl_verify_mode:
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,14 @@ options:
     type: string
     description: "Hostname that email sent by this discourse should appear to come from."
     default: ""
+  smtp_enable_start_tls:
+    type: string
+    description: "enable TLS encryption for smtp connections"
+    default: "true"
+  smtp_force_tls:
+    type: string
+    description: "force implicit TLS as per RFC 8314 3.3"
+    default: "false"
   smtp_openssl_verify_mode:
     type: string
     description: "Should discourse verify SSL certs."

--- a/docs/how-to/configure-smtp.md
+++ b/docs/how-to/configure-smtp.md
@@ -6,6 +6,7 @@ Set `smtp_address`to the SMTP server IP or hostname, `smtp_port` for the SMTP se
 
 If authentication is needed, `smtp_authentication` will need to be set to the appropriate authentication method, valid values are `none`, `login`, `plain`, `cram_md5`. The credentials can be set with `smtp_username`and `smtp_password`.
 
+You can enable/disable SMTP over TLS with the `smtp_force_tls` option and handle starttls with `smtp_enable_start_tls`.  
 If needed, the verification of the SSL certs can be turned on and off with `smtp_openssl_verify_mode`.
 
 For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/discourse-k8s/configure).

--- a/src/charm.py
+++ b/src/charm.py
@@ -410,6 +410,8 @@ class DiscourseCharm(CharmBase):
             "DISCOURSE_SMTP_ADDRESS": self.config["smtp_address"],
             "DISCOURSE_SMTP_AUTHENTICATION": self.config["smtp_authentication"],
             "DISCOURSE_SMTP_DOMAIN": self.config["smtp_domain"],
+            "DISCOURSE_SMTP_ENABLE_START_TLS": self.config["smtp_enable_start_tls"],
+            "DISCOURSE_SMTP_FORCE_TLS": self.config["smtp_force_tls"],
             "DISCOURSE_SMTP_OPENSSL_VERIFY_MODE": self.config["smtp_openssl_verify_mode"],
             "DISCOURSE_SMTP_PASSWORD": self.config["smtp_password"],
             "DISCOURSE_SMTP_PORT": str(self.config["smtp_port"]),


### PR DESCRIPTION
### Overview

Some SMTP relays need more configuration options relative to TLS. This adds `smtp_enable_start_tls` and `smtp_force_tls` to handle those cases.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
