### PR TITLE
Wait for nginx-ingress-integrator being in waiting status instead of active

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -150,7 +150,7 @@ async def app_fixture(
     await model.wait_for_idle(apps=[redis_app.name], status="active")
 
     nii_app = await model.deploy("nginx-ingress-integrator", series="focal", trust=True)
-    await model.wait_for_idle(apps=[nii_app.name], status="active")
+    await model.wait_for_idle(apps=[nii_app.name], status="waiting")
 
     resources = {
         "discourse-image": pytestconfig.getoption("--discourse-image"),


### PR DESCRIPTION
### Overview

The new revision (84) of nginx-ingress-integrator waits for a relation before being active which breaks our integration tests. This is a fix.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
