### PR TITLE
Redis integration. Do not use StoredState.

### DIFF
--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -7,6 +7,7 @@ Charm for Discourse on kubernetes.
 
 **Global Variables**
 ---------------
+- **DEFAULT_RELATION_NAME**
 - **DATABASE_NAME**
 - **DISCOURSE_PATH**
 - **THROTTLE_LEVELS**
@@ -27,7 +28,7 @@ Charm for Discourse on kubernetes.
 ## <kbd>class</kbd> `DiscourseCharm`
 Charm for Discourse on kubernetes. 
 
-<a href="../src/charm.py#L85"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L92"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -412,7 +412,7 @@ def test_start_when_leader():
     act: trigger the start event on a leader unit
     assert: migrations are executed and assets are precompiled.
     """
-    harness = helpers.start_harness()
+    harness = helpers.start_harness(run_initial_hooks=False)
 
     # exec calls that we want to monitor
     exec_calls = [
@@ -444,6 +444,7 @@ def test_start_when_leader():
 
     harness.set_leader(True)
     harness.container_pebble_ready(SERVICE_NAME)
+    # A few events are not emitted, like config_changed.
     harness.charm.on.start.emit()
     harness.framework.reemit()
 
@@ -456,7 +457,7 @@ def test_start_when_not_leader():
     act: trigger the start event on a leader unit
     assert: migrations are executed and assets are precompiled.
     """
-    harness = helpers.start_harness()
+    harness = helpers.start_harness(run_initial_hooks=False)
 
     # exec calls that we want to monitor
     exec_calls = [
@@ -549,23 +550,19 @@ def test_is_database_relation_ready(relation_data, should_be_ready):
     "relation_data, should_be_ready",
     [
         (
-            {"hostname": "redis-host", "port": 1010},
+            {"hostname": "redis-host", "port": "1010"},
             True,
         ),
         (
-            {"hostname": "redis-host", "port": 0},
+            {"hostname": "redis-host", "port": "0"},
             False,
         ),
         (
-            {"hostname": "", "port": 1010},
+            {"hostname": "", "port": "1010"},
             False,
         ),
         (
-            {"hostname": "redis-host", "port": None},
-            False,
-        ),
-        (
-            {"hostname": None, "port": None},
+            {"hostname": "redis-host"},
             False,
         ),
         (
@@ -573,7 +570,7 @@ def test_is_database_relation_ready(relation_data, should_be_ready):
             False,
         ),
         (
-            {"port": 6379},
+            {"port": "6379"},
             False,
         ),
         (

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -490,6 +490,8 @@ def test_start_when_not_leader():
     harness.charm.on.start.emit()
     harness.framework.reemit()
 
+    assert all(expected_exec_call_was_made.values())
+
 
 @pytest.mark.parametrize(
     "relation_data, should_be_ready",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -388,22 +388,6 @@ def test_anonymize_user():
     charm._on_anonymize_user_action(event)
 
 
-def test_handle_pebble_ready_event():
-    """
-    arrange: given a deployed discourse charm with all the required relations
-    act: trigger the pebble ready event on a leader unit
-    assert: the pebble plan gets updated
-    """
-    harness = helpers.start_harness()
-
-    plan_before_event = harness.get_container_pebble_plan(CONTAINER_NAME)
-    harness.container_pebble_ready(CONTAINER_NAME)
-    plan_after_event = harness.get_container_pebble_plan(CONTAINER_NAME)
-    assert plan_before_event.__dict__ != plan_after_event.__dict__
-    assert "_services" in plan_after_event.__dict__
-    assert "discourse" in plan_after_event.__dict__["_services"]
-
-
 def test_handle_redis_relation_changed_event():
     """
     arrange: given a deployed discourse charm with all the required relations

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -388,6 +388,23 @@ def test_anonymize_user():
     charm._on_anonymize_user_action(event)
 
 
+def test_handle_pebble_ready_event():
+    """
+    arrange: given a deployed discourse charm with all the required relations
+    act: trigger the pebble ready event on a leader unit
+    assert: the pebble plan gets updated
+    """
+    harness = helpers.start_harness(run_initial_hooks=False)
+
+    harness.set_can_connect(CONTAINER_NAME, True)
+    plan_before_event = harness.get_container_pebble_plan(CONTAINER_NAME)
+    harness.container_pebble_ready(CONTAINER_NAME)
+    plan_after_event = harness.get_container_pebble_plan(CONTAINER_NAME)
+    assert plan_before_event.__dict__ != plan_after_event.__dict__
+    assert "_services" in plan_after_event.__dict__
+    assert "discourse" in plan_after_event.__dict__["_services"]
+
+
 def test_handle_redis_relation_changed_event():
     """
     arrange: given a deployed discourse charm with all the required relations


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Related to https://github.com/canonical/discourse-k8s-operator/issues/208 (failing S3 upload_assets). Also story ISD-1767.

When the Redis IP address changes, if discourse also restarts/upgrades, it can get into error state, and it will not advance. 
 The charm will be unable to migrate/upload to s3 or any other similar action in the workload, as the Redis IP address is wrong.  The reason for the Redis IP address to be wrong is because it was stored previously in StoredState, being the correct one is in the relation data of the Redis integration.

The fix consists in not using StoredState and getting the IP address from the relation data.
<!-- A high level overview of the change -->

### Rationale

There is a fix that can get Discourse into error state, without any fix except changing the charm code manually (or undeploying the charm).

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
