### PR TITLE
Precompile assets in the rock

### DIFF
--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -231,24 +231,6 @@ parts:
       bin/bundle install --gemfile="plugins/discourse-solved/Gemfile"
       bin/bundle install --gemfile="plugins/discourse-templates/Gemfile"
       yarn install --immutable
-  perms:
-    plugin: nil
-    after: [tooling, discourse, setup, discourse-precompile-assets]
-    override-prime: |
-      chown -R 584792:584792 srv/discourse
-      chown -R 584792:584792 srv/scripts
-      mkdir -p var/lib/pebble/default/.cache
-      mkdir -p var/lib/pebble/default/.config
-      mkdir -p var/lib/pebble/default/.local
-      mkdir -p var/lib/pebble/default/.npm
-      mkdir -p var/lib/pebble/default/.yarn
-      touch var/lib/pebble/default/.yarnrc
-      chown -R 584792:584792 var/lib/pebble/default/.cache
-      chown -R 584792:584792 var/lib/pebble/default/.config
-      chown -R 584792:584792 var/lib/pebble/default/.local
-      chown -R 584792:584792 var/lib/pebble/default/.npm
-      chown -R 584792:584792 var/lib/pebble/default/.yarn
-      chown    584792:584792 var/lib/pebble/default/.yarnrc
   discourse-precompile-assets:
     plugin: nil
     after: [apply-patches, setup]
@@ -267,5 +249,21 @@ parts:
       PATH=$PATH:${CRAFT_PRIME}/usr/bin:${CRAFT_PRIME}/usr/local/bin RAILS_ENV=production DISCOURSE_DB_HOST=127.0.0.1 DISCOURSE_DB_PASSWORD=discourse bundle exec rake assets:precompile
       # Fix the symbolic links.
       find . -lname "${CRAFT_PRIME}/srv/discourse/*" -exec bash -c 'ln -snf "$(readlink "$1" | sed "s~${CRAFT_PRIME}~~")" "$1" ' sh {} \;
-      # TODO there are traces of /root/prime inside the files, not sure if that can cause any issue.
-
+  perms:
+    plugin: nil
+    after: [tooling, discourse, setup, discourse-precompile-assets]
+    override-prime: |
+      chown -R 584792:584792 srv/discourse
+      chown -R 584792:584792 srv/scripts
+      mkdir -p var/lib/pebble/default/.cache
+      mkdir -p var/lib/pebble/default/.config
+      mkdir -p var/lib/pebble/default/.local
+      mkdir -p var/lib/pebble/default/.npm
+      mkdir -p var/lib/pebble/default/.yarn
+      touch var/lib/pebble/default/.yarnrc
+      chown -R 584792:584792 var/lib/pebble/default/.cache
+      chown -R 584792:584792 var/lib/pebble/default/.config
+      chown -R 584792:584792 var/lib/pebble/default/.local
+      chown -R 584792:584792 var/lib/pebble/default/.npm
+      chown -R 584792:584792 var/lib/pebble/default/.yarn
+      chown    584792:584792 var/lib/pebble/default/.yarnrc

--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -243,8 +243,8 @@ parts:
     override-prime: |
       systemctl start postgresql
       cd srv/discourse/app
-      su - postgres -c "psql -c \"CREATE DATABASE discourse;\"" || echo "could not create db, maybe it exists?"
-      su - postgres -c "psql -c \"CREATE USER discourse WITH PASSWORD 'discourse';\"" || echo "could not create user, maybe it exists?"
+      su - postgres -c "psql -c \"CREATE DATABASE discourse;\"" || echo "Could not create database, maybe it already exists."
+      su - postgres -c "psql -c \"CREATE USER discourse WITH PASSWORD 'discourse';\"" || echo "Could not create user, maybe it already exists."
       su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE discourse TO discourse;\""
       PATH=$PATH:${CRAFT_PRIME}/usr/bin:${CRAFT_PRIME}/usr/local/bin RAILS_ENV=production DISCOURSE_DB_HOST=127.0.0.1 DISCOURSE_DB_PASSWORD=discourse bundle exec rake assets:precompile
       # Fix the symbolic links.

--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -233,7 +233,7 @@ parts:
       yarn install --immutable
   perms:
     plugin: nil
-    after: [tooling, discourse, setup]
+    after: [tooling, discourse, setup, discourse-precompile-assets]
     override-prime: |
       chown -R 584792:584792 srv/discourse
       chown -R 584792:584792 srv/scripts
@@ -249,3 +249,23 @@ parts:
       chown -R 584792:584792 var/lib/pebble/default/.npm
       chown -R 584792:584792 var/lib/pebble/default/.yarn
       chown    584792:584792 var/lib/pebble/default/.yarnrc
+  discourse-precompile-assets:
+    plugin: nil
+    after: [apply-patches, setup]
+    build-packages:
+      - redis-tools
+      - postgresql-all
+      - postgresql-client
+    build-snaps:
+      - redis
+    override-prime: |
+      systemctl start postgresql
+      cd srv/discourse/app
+      su - postgres -c "psql -c \"CREATE DATABASE discourse;\"" || echo "could not create db, maybe it exists?"
+      su - postgres -c "psql -c \"CREATE USER discourse WITH PASSWORD 'discourse';\"" || echo "could not create user, maybe it exists?"
+      su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE discourse TO discourse;\""
+      PATH=$PATH:${CRAFT_PRIME}/usr/bin:${CRAFT_PRIME}/usr/local/bin RAILS_ENV=production DISCOURSE_DB_HOST=127.0.0.1 DISCOURSE_DB_PASSWORD=discourse bundle exec rake assets:precompile
+      # Fix the symbolic links.
+      find . -lname "${CRAFT_PRIME}/srv/discourse/*" -exec bash -c 'ln -snf "$(readlink "$1" | sed "s~${CRAFT_PRIME}~~")" "$1" ' sh {} \;
+      # TODO there are traces of /root/prime inside the files, not sure if that can cause any issue.
+

--- a/src/charm.py
+++ b/src/charm.py
@@ -582,25 +582,6 @@ class DiscourseCharm(CharmBase):
             logger.exception("Executing migrations failed with code %d.", cmd_err.exit_code)
             raise
 
-    def _compile_assets(self) -> None:
-        container = self.unit.get_container(CONTAINER_NAME)
-        if not self._are_relations_ready() or not container.can_connect():
-            logger.info("Not ready to compile assets")
-            return
-        env_settings = self._create_discourse_environment_settings()
-        self.model.unit.status = MaintenanceStatus("Compiling assets")
-        try:
-            precompile_process: ExecProcess = container.exec(
-                [f"{DISCOURSE_PATH}/bin/bundle", "exec", "rake", "assets:precompile"],
-                environment=env_settings,
-                working_dir=DISCOURSE_PATH,
-                user=CONTAINER_APP_USERNAME,
-            )
-            precompile_process.wait_output()
-        except ExecError as cmd_err:
-            logger.exception("Compiling assets failed with code %d.", cmd_err.exit_code)
-            raise
-
     def _set_workload_version(self) -> None:
         container = self.unit.get_container(CONTAINER_NAME)
         if not self._are_relations_ready() or not container.can_connect():
@@ -657,8 +638,6 @@ class DiscourseCharm(CharmBase):
         try:
             logger.info("Discourse setup: about to execute migrations")
             self._execute_migrations()
-            logger.info("Discourse setup: about to compile assets")
-            self._compile_assets()
             logger.info("Discourse setup: about to mark the discourse setup process as complete")
             self._set_setup_completed()
             logger.info("Discourse setup: about to set workload version")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -434,7 +434,6 @@ def test_start_when_leader():
     # exec calls that we want to monitor
     exec_calls = [
         [f"{DISCOURSE_PATH}/bin/bundle", "exec", "rake", "--trace", "db:migrate"],
-        [f"{DISCOURSE_PATH}/bin/bundle", "exec", "rake", "assets:precompile"],
         [f"{DISCOURSE_PATH}/bin/rails", "runner", "puts Discourse::VERSION::STRING"],
     ]
 
@@ -478,7 +477,6 @@ def test_start_when_not_leader():
 
     # exec calls that we want to monitor
     exec_calls = [
-        [f"{DISCOURSE_PATH}/bin/bundle", "exec", "rake", "assets:precompile"],
         [f"{DISCOURSE_PATH}/bin/rails", "runner", "puts Discourse::VERSION::STRING"],
     ]
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->

This PR precompiles assets in the rock, instead of doing it in the charm. This will help specially with the deployment and upgrading processes, as they will be much faster.


### Rationale

<!-- The reason the change is needed -->


### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
