### PR TITLE
enable plugins in integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -208,6 +208,7 @@ async def app_fixture(
         '''/srv/discourse/app/bin/bundle exec rake site_settings:import -"'''
     )
 
+    logger.info("Enabling plugins: %s", enable_plugins_command)
     action = await unit.run(f"/bin/bash -c '{enable_plugins_command}'")
     logger.info(action.results)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -210,6 +210,7 @@ async def app_fixture(
 
     logger.info("Enabling plugins: %s", enable_plugins_command)
     action = await unit.run(f"/bin/bash -c '{enable_plugins_command}'")
+    await action.wait()
     logger.info(action.results)
 
     yield application

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,6 +23,14 @@ from . import types
 
 logger = logging.getLogger(__name__)
 
+ENABLED_PLUGINS = [
+    "solved",
+    "saml",
+    "calendar",
+    "data_explorer",
+    "discourse_gamification",
+]
+
 
 @fixture(scope="module", name="metadata")
 def fixture_metadata():
@@ -193,6 +201,14 @@ async def app_fixture(
         model.add_relation(app_name, "nginx-ingress-integrator"),
     )
     await model.wait_for_idle(status="active", raise_on_error=False)
+    inline_yaml = "\n".join(f"{plugin}_enabled: true" for plugin in ENABLED_PLUGINS)
+    enable_plugins_command = (
+        "pebble exec --user=_daemon_ --context=discourse -w=/srv/discourse/app -ti -- /bin/bash -c "
+        f'''"echo '{inline_yaml}' | /srv/discourse/app/bin/bundle exec rake site_settings:import -"'''
+    )
+
+    action = await unit.run(f"/bin/bash -c '{enable_plugins_command}'")
+    logger.info(action.results)
 
     yield application
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -204,7 +204,8 @@ async def app_fixture(
     inline_yaml = "\n".join(f"{plugin}_enabled: true" for plugin in ENABLED_PLUGINS)
     enable_plugins_command = (
         "pebble exec --user=_daemon_ --context=discourse -w=/srv/discourse/app -ti -- /bin/bash -c "
-        f'''"echo '{inline_yaml}' | /srv/discourse/app/bin/bundle exec rake site_settings:import -"'''
+        f""""echo '{inline_yaml}' | """
+        '''/srv/discourse/app/bin/bundle exec rake site_settings:import -"'''
     )
 
     action = await unit.run(f"/bin/bash -c '{enable_plugins_command}'")


### PR DESCRIPTION
Enable all plugins when running integration tests using the `rake site_settings:import` task

```
echo '{settings}' | /srv/discourse/app/bin/bundle exec rake site_settings:import -
```

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
