### PR TITLE
remove raise_on_error

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -190,7 +190,7 @@ async def app_fixture(
             "plugin_pg_trgm_enable": "true",
         }
     )
-    await model.wait_for_idle(apps=[postgres_app.name], status="active", raise_on_error=False)
+    await model.wait_for_idle(apps=[postgres_app.name], status="active")
 
     # Add required relations
     unit = model.applications[app_name].units[0]
@@ -200,7 +200,7 @@ async def app_fixture(
         model.add_relation(app_name, "redis-k8s"),
         model.add_relation(app_name, "nginx-ingress-integrator"),
     )
-    await model.wait_for_idle(status="active", raise_on_error=False)
+    await model.wait_for_idle(status="active")
     inline_yaml = "\n".join(f"{plugin}_enabled: true" for plugin in ENABLED_PLUGINS)
     enable_plugins_command = (
         "pebble exec --user=_daemon_ --context=discourse -w=/srv/discourse/app -ti -- /bin/bash -c "


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->
Remove unneeded `raise_on_error=True` in the integration tests.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
