### PR TITLE
Fix bash to enable plugins in the fixture in the integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -137,6 +137,7 @@ async def app_fixture(
     pytestconfig: Config,
     model: Model,
 ):
+    # pylint: disable=too-many-locals
     """Discourse charm used for integration testing.
     Builds the charm and deploys it and the relations it depends on.
     """
@@ -205,15 +206,20 @@ async def app_fixture(
 
     # Enable plugins calling rake site_settings:import in one of the units.
     inline_yaml = "\n".join(f"{plugin}_enabled: true" for plugin in ENABLED_PLUGINS)
-    logger.info("inline_yaml %s", inline_yaml)
     discourse_rake_command = "/srv/discourse/app/bin/bundle exec rake site_settings:import "
-    pebble_exec = "PEBBLE_SOCKET=/charm/containers/discourse/pebble.socket pebble exec --user=_daemon_ --context=discourse -w=/srv/discourse/app"
-    full_command = f"/bin/bash -c 'echo \"{inline_yaml}\" | {pebble_exec} -- {discourse_rake_command}'"
-    logger.info("Full command: %s", full_command)
+    pebble_exec = (
+        "PEBBLE_SOCKET=/charm/containers/discourse/pebble.socket "
+        "pebble exec --user=_daemon_ --context=discourse -w=/srv/discourse/app"
+    )
+    full_command = (
+        "/bin/bash -c "
+        f"'set -euo pipefail; echo \"{inline_yaml}\" | {pebble_exec} -- {discourse_rake_command}'"
+    )
+    logger.info("Enable plugins command: %s", full_command)
     action = await unit.run(full_command)
     await action.wait()
     logger.info(action.results)
-    assert action.results['return-code'] == 0, "Enable plugins failed"
+    assert action.results["return-code"] == 0, "Enable plugins failed"
 
     yield application
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -202,17 +202,18 @@ async def app_fixture(
         model.add_relation(app_name, "nginx-ingress-integrator"),
     )
     await model.wait_for_idle(status="active")
-    inline_yaml = "\n".join(f"{plugin}_enabled: true" for plugin in ENABLED_PLUGINS)
-    enable_plugins_command = (
-        "pebble exec --user=_daemon_ --context=discourse -w=/srv/discourse/app -ti -- /bin/bash -c "
-        f""""echo '{inline_yaml}' | """
-        '''/srv/discourse/app/bin/bundle exec rake site_settings:import -"'''
-    )
 
-    logger.info("Enabling plugins: %s", enable_plugins_command)
-    action = await unit.run(f"/bin/bash -c '{enable_plugins_command}'")
+    # Enable plugins calling rake site_settings:import in one of the units.
+    inline_yaml = "\n".join(f"{plugin}_enabled: true" for plugin in ENABLED_PLUGINS)
+    logger.info("inline_yaml %s", inline_yaml)
+    discourse_rake_command = "/srv/discourse/app/bin/bundle exec rake site_settings:import "
+    pebble_exec = "PEBBLE_SOCKET=/charm/containers/discourse/pebble.socket pebble exec --user=_daemon_ --context=discourse -w=/srv/discourse/app"
+    full_command = f"/bin/bash -c 'echo \"{inline_yaml}\" | {pebble_exec} -- {discourse_rake_command}'"
+    logger.info("Full command: %s", full_command)
+    action = await unit.run(full_command)
     await action.wait()
     logger.info(action.results)
+    assert action.results['return-code'] == 0, "Enable plugins failed"
 
     yield application
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ deps =
     isort
     juju>=3.0
     mypy
-    ops>=2.6.0
+    ops==2.12.0
     ops-lib-pgsql
     pep8-naming
     psycopg2-binary


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->

The code for enabling plugins in the integrations tests (just after deploying discourse) was not working. 

The code has been updated (it is a bash command that runs a rake task in one of the units). Also an assert has been added, so if the command fails, the fixture fails.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
