### PR TITLE
Update tutorial to reflect new create-user action

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -79,10 +79,12 @@ juju trust nginx-ingress-integrator --scope=cluster
 juju relate discourse-k8s nginx-ingress-integrator
 ```
 
-Discourse will be deployed with `discourse-k8s` as default hostname. In order to reach it, modify your `/etc/hosts` file so that it points to `127.0.0.1`
+To create an admin user, run:
+```
+juju run discourse-k8s/0 create-user admin=true email=email@example.com
+```
+The command will return the password of the created user. Discourse will be deployed with `discourse-k8s` as default hostname. In order to reach it, modify your `/etc/hosts` file so that it points to `127.0.0.1`
 
 `echo 127.0.0.1 discourse-k8s >> /etc/hosts`
 
-After that, visit `http://discourse-k8s` to reach Discourse.
-
-This charm allows you to add a admin user by executing the corresponding action. Instead of interacting with the Discourse UI just run `juju run discourse-k8s/0 add-admin-user email=email@example.com password=somelongpwd` and it will be registered and validated.
+After that, visit `http://discourse-k8s` to reach Discourse, using the credentials returned from the `create-user` action to login.


### PR DESCRIPTION
### Overview

Trivial doc update for the tutorial to incorporate the new `create-user` action. I think changing the ordering a little to create the user before visiting the page makes sense too, as this will mean you get a "log in" prompt rather than a "register your first user" prompt.

### Rationale

The action specified in the tutorial no longer exists, so update to include the new action.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A
### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)