### PR TITLE
Chat integration plugin

### DIFF
--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -177,7 +177,7 @@ parts:
     plugin: dump
     after: [discourse, bundler-config]
     source: https://github.com/discourse/discourse-chat-integration.git
-    source-commit: 5c8408e58b6ad0c5e2ad495861a91c231bb1fc89
+    source-commit: 2e17b03e9a435de0079ae1c2eed1b48a11ad16a9
     source-depth: 1
     organize:
       "*": srv/discourse/app/plugins/discourse-chat-integration/

--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -173,6 +173,14 @@ parts:
     source-depth: 1
     organize:
       "*": srv/discourse/app/plugins/discourse-gamification/
+  discourse-chat-integration:
+    plugin: dump
+    after: [discourse, bundler-config]
+    source: https://github.com/discourse/discourse-chat-integration.git
+    source-commit: 5c8408e58b6ad0c5e2ad495861a91c231bb1fc89
+    source-depth: 1
+    organize:
+      "*": srv/discourse/app/plugins/discourse-chat-integration/
   patches:
     plugin: dump
     after: [discourse]
@@ -215,6 +223,7 @@ parts:
       - discourse-saml
       - discourse-solved
       - discourse-templates
+      - discourse-chat-integration
       - patches
       - scripts
       - tooling
@@ -233,6 +242,7 @@ parts:
       bin/bundle install --gemfile="plugins/discourse-saml/Gemfile"
       bin/bundle install --gemfile="plugins/discourse-solved/Gemfile"
       bin/bundle install --gemfile="plugins/discourse-templates/Gemfile"
+      bin/bundle install --gemfile="plugins/discourse-chat-integration/Gemfile"
       yarn install --immutable
   discourse-precompile-assets:
     plugin: nil

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -30,6 +30,7 @@ ENABLED_PLUGINS = [
     "calendar",
     "data_explorer",
     "discourse_gamification",
+    "chat_integration",
 ]
 
 


### PR DESCRIPTION
Add [the discourse-chat-integration plugin](https://github.com/discourse/discourse-chat-integration)
### Overview
Add [the discourse-chat-integration plugin](https://github.com/discourse/discourse-chat-integration) to the Discourse Rock.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
