### PR TITLE
Update docs

### DIFF
--- a/docs/how-to/access--the-rails-console.md
+++ b/docs/how-to/access--the-rails-console.md
@@ -1,7 +1,7 @@
 # How to access the Rails console
 
-Ideally, the discourse charm should be handled by interacting with Juju, and everything that can be done with the console should
-be doable with juju actions. In case there is something that needs to be done with the console anyway, the console can be accessed.
+Ideally, the Discourse charm should be handled by interacting with Juju, and everything that can be done with the console should
+be doable with Juju actions. In case there is something that needs to be done with the console anyway, the console can be accessed.
 
 ### Prerequisites
 
@@ -9,7 +9,7 @@ Have a Discourse deployment active.
 
 ### Access the console
 
-First of all, switch into the juju Discourse model if necessary:
+First of all, switch into the Juju Discourse model if necessary:
 ```
 juju switch discourse-model
 ```

--- a/docs/how-to/configure-container.md
+++ b/docs/how-to/configure-container.md
@@ -1,9 +1,9 @@
 # How to configure the container
 
-This charm exposes several configurations to tweak the behaviour of discourse. These can by changes by running `juju config [charm_name] [configuration]=[value]`. Below you can find some of the options that will allow you to modify the charm's behaviour:
+This charm exposes several configurations to tweak the behaviour of Discourse. These can by changes by running `juju config [charm_name] [configuration]=[value]`. Below you can find some of the options that will allow you to modify the charm's behaviour:
 
 * CORS policies can be modified with the settings [cors_origin](https://charmhub.io/discourse-k8s/configure#cors_origin) and [enable_cors](https://charmhub.io/discourse-k8s/configure#enable_cors)
 * The developer mails can be set through [developer_emails](https://charmhub.io/discourse-k8s/configure#developer_emails)
-* Throttle level protections provided by discourse can be changed via [throttle_level](https://charmhub.io/discourse-k8s/configure#throttle_level)
+* Throttle level protections provided by Discourse can be changed via [throttle_level](https://charmhub.io/discourse-k8s/configure#throttle_level)
 
 For a comprehensive list of configuration options check the [configuration reference](https://charmhub.io/discourse-k8s/configure).

--- a/docs/how-to/configure-s3.md
+++ b/docs/how-to/configure-s3.md
@@ -13,7 +13,7 @@ s3_secret_access_key
 
 To enable S3 to perform backups, you'll need to specify also `s3_backup_bucket`.
 
-It is also possible to configure the S3 bucket to act as a content delivery network (CDN) serving the static content directly from the bucket, for that, set `s3_cdn_url`. If you wish to modify the CORS set up, you can do so by changing `s3_install_cors_rule`.
+It is also possible to configure the S3 bucket to act as a content delivery network (CDN) serving the static content directly from the bucket; for that, set `s3_cdn_url`. If you wish to modify the CORS set up, you can do so by changing `s3_install_cors_rule`.
 
 
 For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/discourse-k8s/configure).

--- a/docs/how-to/configure-saml.md
+++ b/docs/how-to/configure-saml.md
@@ -4,7 +4,7 @@ To configure Discourse's SAML integration you'll have to set the following confi
 
 If you wish to force the login to go through SAML, enable `force_saml_login`.
 The groups to be synced from the provider can be defined in `saml_sync_groups` as a comma-separated list of values.
-In order to implement the relation discourse has to be related with the [saml-integrator](https://charmhub.io/saml-integrator):
+In order to implement the relation, Discourse has to be related with the [saml-integrator](https://charmhub.io/saml-integrator):
 ```
 juju deploy saml-integrator --channel=edge
 # Set the SAML integrator configs

--- a/docs/how-to/contribute.md
+++ b/docs/how-to/contribute.md
@@ -9,7 +9,7 @@ enhancements to the Discourse operator.
 [opening an issue](https://github.com/canonical/discourse-k8s-operator/issues)
 explaining your use case.
 - If you would like to chat with us about your use-cases or proposed
-implementation, you can reach us at [Canonical Mattermost public channel](https://chat.charmhub.io/charmhub/channels/charm-dev)
+implementation, you can reach us at [Canonical Matrix public channel](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)
 or [Discourse](https://discourse.charmhub.io/).
 - Familiarising yourself with the [Charmed Operator Framework](https://juju.is/docs/sdk)
 library will help you a lot when working on new features or bug fixes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ fixes and constructive feedback.
 
 - [Code of conduct](https://ubuntu.com/community/code-of-conduct)
 - [Get support](https://discourse.charmhub.io/)
-- [Join our online chat](https://chat.charmhub.io/charmhub/channels/charm-dev)
+- [Join our online chat](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)
 - [Contribute](https://charmhub.io/discourse-k8s/docs/how-to-contribute)
 
 # Contents

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -12,27 +12,32 @@ You will need:
 ## Deploy this charm
 
 Discourse requires connections to PostgreSQL and Redis, so those will be deployed too and related to the Discourse charm. For more information, see the [Charm Architecture](https://charmhub.io/discourse-k8s/docs/charm-architecture).
-Note that Discourse requires PostgreSQL extensions to be available in the relation.
+
+> NOTE: Discourse requires PostgreSQL extensions to be available in the relation.
 
 All the above charms will the deployed in a new model named `discourse`:
 
 ```
-# Add the model
 juju add-model discourse
+```
 
-# Deploy the charms
+Deploy the charms:
+```
 juju deploy redis-k8s --channel latest/edge
 juju deploy postgresql-k8s --channel 14/stable --trust
 juju deploy discourse-k8s
+```
 
-# Enable required PostgreSQL extensions
+Enable the required PostgreSQL extensions:
+```
 juju config postgresql-k8s plugin_hstore_enable=True
 juju config postgresql-k8s plugin_pg_trgm_enable=True
+```
 
-# Relate redis-k8s and postgresql-k8s to discourse-k8s
+Relate `redis-k8s` and `postgresql-k8s` to `discourse-k8s`:
+```
 juju relate redis-k8s discourse-k8s
 juju relate discourse-k8s postgresql-k8s
-
 ```
 
 By running `juju status --relations` the current state of the deployment can be queried, with all the charms eventually reaching `Active`state:


### PR DESCRIPTION
### Overview

Smaller documentation changes that are specific to the Discourse charm 

### Rationale

- Index page: Fixed outdated link
- Tutorial: Reformatted one sentence as a note; split up the first block of commands into smaller steps to improve readability (especially for novice users)
- How-to guides: Capitalising non-code references to Juju and Discourse; updated an outdated link; some small grammar changes

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
