### PR TITLE
Feat(): Set `UNICORN_SIDEKIQ_MAX_RSS` env variable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -138,3 +138,8 @@ options:
     type: string
     description: "Throttle level - blocks excessive usage by ip. Accepted values: none, permissive, strict."
     default: none
+  sidekiq_max_memory:
+    description: Maximum memory for sidekiq in megabytes. This configuration
+      will set the UNICORN_SIDEKIQ_MAX_RSS environment variable.
+    type: int
+    default: 1000

--- a/src/charm.py
+++ b/src/charm.py
@@ -453,6 +453,7 @@ class DiscourseCharm(CharmBase):
             "DISCOURSE_SMTP_PORT": str(self.config["smtp_port"]),
             "DISCOURSE_SMTP_USER_NAME": self.config["smtp_username"],
             "RAILS_ENV": "production",
+            "UNICORN_SIDEKIQ_MAX_RSS": str(self.config["sidekiq_max_memory"]),
         }
         pod_config.update(self._get_saml_config())
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -516,6 +516,23 @@ def test_anonymize_user():
     assert expected_exec_call_was_made
 
 
+def test_sidekiq_env_variable():
+    """
+    arrange: given a deployed discourse charm with all the required relations
+    act: trigger the pebble ready event on a leader unit
+    assert: the pebble plan gets updated
+    """
+    harness = helpers.start_harness(run_initial_hooks=False)
+
+    harness.set_can_connect(CONTAINER_NAME, True)
+    harness.container_pebble_ready(CONTAINER_NAME)
+    plan_before_set_config = harness.get_container_pebble_plan(CONTAINER_NAME).services["discourse"].environment
+    harness.update_config({"sidekiq_max_memory": 500})
+    plan_after_set_config = harness.get_container_pebble_plan(CONTAINER_NAME).services["discourse"].environment
+    assert plan_before_set_config != plan_after_set_config
+    assert "1000" in plan_before_set_config["UNICORN_SIDEKIQ_MAX_RSS"]
+    assert "500" in plan_after_set_config["UNICORN_SIDEKIQ_MAX_RSS"]
+
 def test_handle_pebble_ready_event():
     """
     arrange: given a deployed discourse charm with all the required relations

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -526,12 +526,17 @@ def test_sidekiq_env_variable():
 
     harness.set_can_connect(CONTAINER_NAME, True)
     harness.container_pebble_ready(CONTAINER_NAME)
-    plan_before_set_config = harness.get_container_pebble_plan(CONTAINER_NAME).services["discourse"].environment
+    plan_before_set_config = (
+        harness.get_container_pebble_plan(CONTAINER_NAME).services["discourse"].environment
+    )
     harness.update_config({"sidekiq_max_memory": 500})
-    plan_after_set_config = harness.get_container_pebble_plan(CONTAINER_NAME).services["discourse"].environment
+    plan_after_set_config = (
+        harness.get_container_pebble_plan(CONTAINER_NAME).services["discourse"].environment
+    )
     assert plan_before_set_config != plan_after_set_config
     assert "1000" in plan_before_set_config["UNICORN_SIDEKIQ_MAX_RSS"]
     assert "500" in plan_after_set_config["UNICORN_SIDEKIQ_MAX_RSS"]
+
 
 def test_handle_pebble_ready_event():
     """


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->
Created an  option to set the `UNICORN_SIDEKIQ_MAX_RSS` env variable due to [issue](https://github.com/canonical/discourse-k8s-operator/issues/306)
<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
