### PR TITLE
Use latest version supporting 3.3

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,5 +14,4 @@ jobs:
       juju-channel: 3.1/stable
       channel: 1.28-strict/stable
       modules: '["test_charm", "test_saml", "test_users", "test_db_migration"]'
-      self-hosted-runner: true
-      self-hosted-runner-label: "edge"
+      self-hosted-runner: false

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,4 +14,5 @@ jobs:
       juju-channel: 3.1/stable
       channel: 1.28-strict/stable
       modules: '["test_charm", "test_saml", "test_users", "test_db_migration"]'
-      self-hosted-runner: false
+      self-hosted-runner: true
+      self-hosted-runner-label: "edge"

--- a/.trivyignore
+++ b/.trivyignore
@@ -34,4 +34,4 @@ private-key
 CVE-2024-53103
 # libc
 CVE-2024-56658
-
+CVE-2024-35864

--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -98,7 +98,7 @@ parts:
     plugin: dump
     after: [discourse, bundler-config]
     source: https://github.com/canonical-web-and-design/discourse-markdown-note.git
-    source-commit: f4426d5929de067f123659dc690e9438a324817a
+    source-commit: a0d7276360db732c2252507e207ebadd2ffc9fbe
     source-depth: 1
     organize:
       "*": srv/discourse/app/plugins/markdown-note/

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -156,8 +156,7 @@ async def app_fixture(
         trust=True,
         config={"profile": "testing"},
     )
-    async with ops_test.fast_forward():
-        await model.wait_for_idle(apps=[postgres_app.name], status="active")
+    await model.wait_for_idle(apps=[postgres_app.name], status="active")
 
     redis_app = await model.deploy("redis-k8s", series="jammy", channel="latest/edge")
     await model.wait_for_idle(apps=[redis_app.name], status="active")

--- a/tests/integration/test_db_migration.py
+++ b/tests/integration/test_db_migration.py
@@ -34,8 +34,7 @@ async def test_db_migration(model: Model, ops_test: OpsTest, pytestconfig: Confi
         trust=True,
         config={"profile": "testing"},
     )
-    async with ops_test.fast_forward():
-        await model.wait_for_idle(apps=[postgres_app.name], status="active")
+    await model.wait_for_idle(apps=[postgres_app.name], status="active")
     await postgres_app.set_config(
         {
             "plugin_hstore_enable": "true",


### PR DESCRIPTION
Upgrading to discourse 3.3 breaks the compatibility with the pinned discourse-markdown-note module.
A new version of the module has been released, and we're updating the dependency accordingly.
