### PR TITLE
feat/ISD-3609: Add multi-level category setting to charm config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,7 +37,7 @@ options:
     default: false
   max_category_nesting:
     type: int
-    description: "Maximum category nesting allowed."
+    description: "Maximum category nesting allowed. Minimum is 2, maximum is 3."
     default: 2
   saml_sync_groups:
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,10 @@ options:
     type: boolean
     description: "Force SAML login (full screen, no local database logins)."
     default: false
+  max_category_nesting:
+    type: int
+    description: "Maximum category nesting allowed."
+    default: 2
   saml_sync_groups:
     type: string
     description: "Comma-separated list of groups to sync from SAML provider."

--- a/src/charm.py
+++ b/src/charm.py
@@ -465,6 +465,7 @@ class DiscourseCharm(CharmBase):
             "DISCOURSE_DEVELOPER_EMAILS": self.config["developer_emails"],
             "DISCOURSE_ENABLE_CORS": str(self.config["enable_cors"]).lower(),
             "DISCOURSE_HOSTNAME": self._get_external_hostname(),
+            "DISCOURSE_MAX_CATEGORY_NESTING": str(self.config["max_category_nesting"]),
             "DISCOURSE_REDIS_HOST": redis_relation_data[0],
             "DISCOURSE_REDIS_PORT": str(redis_relation_data[1]),
             "DISCOURSE_REFRESH_MAXMIND_DB_DURING_PRECOMPILE_DAYS": "0",

--- a/src/charm.py
+++ b/src/charm.py
@@ -69,6 +69,7 @@ LOG_PATHS = [
     f"{DISCOURSE_PATH}/log/unicorn.stderr.log",
     f"{DISCOURSE_PATH}/log/unicorn.stdout.log",
 ]
+MAX_CATEGORY_NESTING_LEVELS = [2, 3]
 PROMETHEUS_PORT = 3000
 REQUIRED_S3_SETTINGS = ["s3_access_key_id", "s3_bucket", "s3_region", "s3_secret_access_key"]
 SCRIPT_PATH = "/srv/scripts"
@@ -311,7 +312,11 @@ class DiscourseCharm(CharmBase):
             and self.model.get_relation(DEFAULT_RELATION_NAME) is None
         ):
             errors.append("force_saml_login cannot be true without a saml relation")
-
+        if self.config["max_category_nesting"] not in MAX_CATEGORY_NESTING_LEVELS:
+            errors.append(
+                "max_category_nesting must be one of: "
+                f"{', '.join(map(str, MAX_CATEGORY_NESTING_LEVELS))}"
+            )
         if (
             self.config["saml_sync_groups"]
             and self.model.get_relation(DEFAULT_RELATION_NAME) is None

--- a/tests/unit_harness/test_charm.py
+++ b/tests/unit_harness/test_charm.py
@@ -201,6 +201,7 @@ def test_on_config_changed_when_valid_no_s3_backup_nor_cdn():
     assert "someuser" == updated_plan_env["DISCOURSE_DB_USERNAME"]
     assert updated_plan_env["DISCOURSE_ENABLE_CORS"]
     assert "discourse-k8s" == updated_plan_env["DISCOURSE_HOSTNAME"]
+    assert "2" == updated_plan_env["DISCOURSE_MAX_CATEGORY_NESTING"]
     assert "redis-host" == updated_plan_env["DISCOURSE_REDIS_HOST"]
     assert "1010" == updated_plan_env["DISCOURSE_REDIS_PORT"]
     assert updated_plan_env["DISCOURSE_SERVE_STATIC_ASSETS"]
@@ -258,6 +259,7 @@ def test_on_config_changed_when_valid():
     assert "user@foo.internal" == updated_plan_env["DISCOURSE_DEVELOPER_EMAILS"]
     assert updated_plan_env["DISCOURSE_ENABLE_CORS"]
     assert "discourse.local" == updated_plan_env["DISCOURSE_HOSTNAME"]
+    assert "2" == updated_plan_env["DISCOURSE_MAX_CATEGORY_NESTING"]
     assert "redis-host" == updated_plan_env["DISCOURSE_REDIS_HOST"]
     assert "1010" == updated_plan_env["DISCOURSE_REDIS_PORT"]
     assert updated_plan_env["DISCOURSE_SAML_CERT_FINGERPRINT"] is not None


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

Applicable ticket: ISD-3609

### Overview

Added `max_category_nesting` config option, which allows the configuration for the number of nested categories one can create. This is a Discourse option, this PR only enables the ability to change the configuration option in the Discourse app through the charm.

### Rationale

This was a requested feature to be implemented so that more nested categories could be added.

### Juju events changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The changelog is updated.
<!-- Explanation for any unchecked items above -->
