### PR TITLE
Add tox lint-docs target to check broken links

### DIFF
--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -70,7 +70,7 @@ UpdateRelStyle(discourse_charm, postgresql_charm, $textColor="blue", $offsetX="2
 
 ## Containers
 
-Configuration files for the containers can be found in [the image directory of the charm repository](https://github.com/canonical/discourse-k8s-operator/tree/main/image).
+Configuration files for the workload can be found [here](https://github.com/canonical/discourse-k8s-operator/blob/main/config.yaml).
 
 ### Discourse
 
@@ -94,7 +94,7 @@ This section provides information about the integrations.
 
 The Discourse charm also supports being integrated with [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/#what-is-ingress) by using [NGINX Ingress Integrator](https://charmhub.io/nginx-ingress-integrator/).
 
-In this case, an existing Ingress controller is required. For more information, see [Adding the Ingress Relation to a Charm](https://charmhub.io/nginx-ingress-integrator/docs/adding-ingress-relation).
+In this case, an existing Ingress controller is required. For more information, see [Adding the Ingress Relation to a Charm](https://charmhub.io/nginx-ingress-integrator/docs/add-the-ingress-relation).
 
 ### PostgreSQL
 
@@ -119,8 +119,8 @@ Accordingly to the [Juju SDK](https://juju.is/docs/sdk/event): "an event is a da
 
 For this charm, the following events are observed:
 
-1. [<container name>_pebble_ready](https://juju.is/docs/sdk/container-name-pebble-ready-event): fired on Kubernetes charms when the requested container is ready. Action: wait for the integrations, and configure the containers.
-2. [config_changed](https://juju.is/docs/sdk/config-changed-event): usually fired in response to a configuration change using the GUI or CLI. Action: wait for the integrations, validate the configuration, update Ingress, and restart the containers.
+1. [<container name>_pebble_ready](https://documentation.ubuntu.com/juju/3.6/reference/hook/#container-pebble-ready): fired on Kubernetes charms when the requested container is ready. Action: wait for the integrations, and configure the containers.
+2. [config_changed](https://documentation.ubuntu.com/juju/3.6/reference/hook/#config-changed): usually fired in response to a configuration change using the GUI or CLI. Action: wait for the integrations, validate the configuration, update Ingress, and restart the containers.
 3. [add_admin_user_action](https://charmhub.io/discourse-k8s/actions): fired when add-admin-user action is executed. Action: add an admin user with the provided email and password.
 <!-- vale Canonical.400-Enforce-inclusive-terms = NO -->
 <!-- master refers to the main database -->
@@ -135,6 +135,6 @@ The `src/charm.py` is the default entry point for a charm and has the DiscourseC
 
 CharmBase is the base class from which all Charms are formed, defined by [Ops](https://juju.is/docs/sdk/ops) (Python framework for developing charms).
 
-See more information in [Charm](https://juju.is/docs/sdk/constructs#heading--charm).
+See more information in [Charm](https://documentation.ubuntu.com/juju/3.6/howto/manage-charms/#build-a-charm).
 
 The `__init__` method guarantees that the charm observes all events relevant to its operation and handles them.

--- a/docs/how-to/backup-and-restore.md
+++ b/docs/how-to/backup-and-restore.md
@@ -36,8 +36,8 @@ If the same S3 bucket can be used in the restored Discourse instance, then it is
 to backup the database.
 
 This can be easily done with [Charmed PostgreSQL](https://charmhub.io/postgresql) and [Charmed PostgreSQL K8s](https://charmhub.io/postgresql-k8s).
-See [How to create and list backups in Charmed PostgreSQL](https://charmhub.io/postgresql/docs/h-create-and-list-backups)
-or [How to create and list backups in Charmed PostgreSQL K8s](https://charmhub.io/postgresql-k8s/docs/h-create-and-list-backups) for the full procedure.
+See [How to create and list backups in Charmed PostgreSQL](https://canonical-charmed-postgresql.readthedocs-hosted.com/latest/how-to/back-up-and-restore/create-a-backup/)
+or [How to create and list backups in Charmed PostgreSQL K8s](https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/latest/how-to/back-up-and-restore/create-a-backup/) for the full procedure.
 
 To restore Discourse, once it is deployed and configured as the Discourse instance to restore, it is only necessary
 to restore the database. The instructions, depending on the configuration, can be found in the next links:

--- a/docs/how-to/backup-and-restore.md
+++ b/docs/how-to/backup-and-restore.md
@@ -42,9 +42,9 @@ or [How to create and list backups in Charmed PostgreSQL K8s](https://canonical-
 To restore Discourse, once it is deployed and configured as the Discourse instance to restore, it is only necessary
 to restore the database. The instructions, depending on the configuration, can be found in the next links:
  - Charmed PostgreSQL. Local backup: https://charmhub.io/postgresql/docs/h-restore-backup
- - Charmed PostgreSQL. Migrate a cluster: https://charmhub.io/postgresql/docs/h-migrate-cluster-via-restore
+ - Charmed PostgreSQL. Migrate a cluster: https://canonical-charmed-postgresql.readthedocs-hosted.com/latest/how-to/back-up-and-restore/migrate-a-cluster/
  - Charmed PostgreSQL K8s. Local backup: https://charmhub.io/postgresql-k8s/docs/h-restore-backup
- - Charmed PostgreSQL K8s. Migrate a cluster: https://charmhub.io/postgresql-k8s/docs/h-migrate-cluster-via-restore
+ - Charmed PostgreSQL K8s. Migrate a cluster: https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/latest/how-to/back-up-and-restore/migrate-a-cluster/
 
 ## S3 and the backup and restore procedure
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 <!-- "Operator" is part of the name -->
 # Discourse Operator
 <!-- vale Canonical.007-Headings-sentence-case = YES -->
-A [Juju](https://juju.is/) [charm](https://juju.is/docs/olm/charmed-operators) deploying and managing Discourse on Kubernetes.
+A [Juju](https://juju.is/) [charm](https://documentation.ubuntu.com/juju/3.6/reference/charm/) deploying and managing Discourse on Kubernetes.
 
 Discourse is an open-source software application used to create customer-friendly and community-friendly discussion platforms, 
 forums, and mailing lists. It's designed to work as a discussion platform for various topics and is widely used by numerous 

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -59,7 +59,7 @@ juju integrate discourse-k8s nginx-ingress-integrator
 ### metrics-endpoint
 <!-- vale Canonical.000-US-spellcheck = NO -->
 <!-- prometheus_scrape is the name of the interface>
-_Interface_: [prometheus_scrape](https://charmhub.io/interfaces/prometheus_scrape-v0)
+_Interface_: [prometheus_scrape](https://charmhub.io/interfaces/prometheus_scrape)
 <!-- vale Canonical.000-US-spellcheck = YES -->
 
 _Supported charms_: [prometheus-k8s](https://charmhub.io/prometheus-k8s)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -38,7 +38,7 @@ juju add-model discourse-tutorial
 
 ### Deploy the charms
 
-Discourse requires connections to PostgreSQL and Redis. For more information, see the [Charm Architecture](https://charmhub.io/discourse-k8s/docs/charm-architecture).
+Discourse requires connections to PostgreSQL and Redis. For more information, see the [Charm Integrations](https://charmhub.io/discourse-k8s/docs/reference-integrations).
 
 > NOTE: Discourse requires PostgreSQL extensions to be available in the relation.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -10,10 +10,10 @@ In this tutorial, we'll go through each step of the process to get a basic Disco
 
 ## Requirements
 - A working station, e.g., a laptop, with amd64 architecture.
-- Juju 3 installed and bootstrapped to a MicroK8s controller. You can accomplish this process by using a Multipass VM as outlined in this guide: [Set up / Tear down your test environment]([https://juju.is/docs/juju/set-up--tear-down-your-test-environment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/#set-up-your-deployment-local-testing-and-development))
+- Juju 3 installed and bootstrapped to a MicroK8s controller. You can accomplish this process by using a Multipass VM as outlined in this guide: [Set up / Tear down your test environment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/#set-up-your-deployment-local-testing-and-development)
 - NGINX Ingress Controller. If you're using [MicroK8s](https://microk8s.io/), this can be done by running the command `microk8s enable ingress`. For more details, see [Add-on: Ingress](https://microk8s.io/docs/addon-ingress).
 
-For more information about how to install Juju, see [Get started with Juju]([https://juju.is/docs/olm/get-started-with-juju](https://documentation.ubuntu.com/juju/3.6/tutorial/)).
+For more information about how to install Juju, see [Get started with Juju](https://documentation.ubuntu.com/juju/3.6/tutorial/).
 
 :warning: When using a Multipass VM, make sure to replace `127.0.0.1` IP addresses with the
 VM IP in steps that assume you're running locally. To get the IP address of the

--- a/tox.ini
+++ b/tox.ini
@@ -123,15 +123,19 @@ deps =
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --ignore={[vars]tst_path}unit_harness --log-cli-level=INFO -s {posargs}
 
-
 [testenv:lint-docs]
-description = Validate documentation style and links
-deps =
-    brotli
-    linkcheckmd
-    -r{toxinidir}/requirements.txt
+skip_install = true
+allowlist_externals =
+    curl
+    tar
+    chmod
+    {envtmpdir}/lychee
+commands_pre =
+    curl -L https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz -o {envtmpdir}/lychee.tar.gz
+    tar -xzf {envtmpdir}/lychee.tar.gz -C {envtmpdir}
+    chmod +x {envtmpdir}/lychee
 commands =
-    python -m linkcheckmd -r {[vars]docs_path}
+    {envtmpdir}/lychee --max-concurrency 2 README.md {[vars]docs_path}
 
 [testenv:src-docs]
 allowlist_externals=sh

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist = lint, unit, static, coverage-report
 [vars]
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
+docs_path = {toxinidir}/docs
 ;lib_path = {toxinidir}/lib/charms/operator_name_with_underscores
 all_path = {[vars]src_path} {[vars]tst_path}
 
@@ -121,6 +122,16 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --ignore={[vars]tst_path}unit_harness --log-cli-level=INFO -s {posargs}
+
+
+[testenv:lint-docs]
+description = Validate documentation style and links
+deps =
+    brotli
+    linkcheckmd
+    -r{toxinidir}/requirements.txt
+commands =
+    python -m linkcheckmd -r {[vars]docs_path}
 
 [testenv:src-docs]
 allowlist_externals=sh

--- a/tox.ini
+++ b/tox.ini
@@ -129,9 +129,17 @@ allowlist_externals =
     curl
     tar
     chmod
+    echo
+    sh
     {envtmpdir}/lychee
+setenv =
+    LYCHEE_VERSION = 0.19.1
+    EXPECTED_SHA256 = 537bcfbb0f3bf997f4cbdab259cc5500f2804b69614140ac3edebb4de94b3574
+    DOWNLOAD_URL = https://github.com/lycheeverse/lychee/releases/download/lychee-v{env:LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz
 commands_pre =
-    curl -L https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz -o {envtmpdir}/lychee.tar.gz
+    echo "Download URL: {env:DOWNLOAD_URL}"
+    curl -L {env:DOWNLOAD_URL} -o {envtmpdir}/lychee.tar.gz
+    sh -c "echo '{env:EXPECTED_SHA256}  {envtmpdir}/lychee.tar.gz' | sha256sum -c -"
     tar -xzf {envtmpdir}/lychee.tar.gz -C {envtmpdir}
     chmod +x {envtmpdir}/lychee
 commands =


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Following the UX session, some links were raised as broken. 

### Rationale

We need our linting workflow to check all links within our docs so we catch broken links before anyone lands on them.

To that effect, this PR adds a new tox target `lint-docs` which checks all links referenced in our `docs` folder. If any are found, the command will output them and then fail.

![image](https://github.com/user-attachments/assets/40698ab6-94e8-4fdb-8e8e-b4abe8a51b26)

