### PR TITLE
Feat: Introduce a unified Makefile-based development workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,71 +104,127 @@ To add signatures on your commits, follow the
 
 ## Develop
 
-To make contributions to this charm, you'll need a working
-[development setup](https://documentation.ubuntu.com/juju/latest/user/howto/manage-your-deployment/manage-your-deployment-environment/).
+To make contributions to this charm, you'll need a working [Juju development setup](https://documentation.ubuntu.com/juju/latest/howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development/index.html.
 
-The code for this charm can be downloaded as follows:
-
-```
-git clone https://github.com/canonical/discourse-k8s-operator
-```
-
-You can create an environment for development with `python3-venv`:
+First, clone the repository:
 
 ```bash
-sudo apt install python3-venv
-python3 -m venv venv
-source venv/bin/activate
-pip install tox
+git clone https://github.com/canonical/discourse-k8s-operator.git
+cd discourse-k8s-operator
 ```
 
-Install `tox` inside the virtual environment for testing.
+### Local Development and Testing
 
-### Test
+Our development workflow is managed by make. This provides a consistent set of commands for building, testing, and deploying the charm.
 
-This project uses `tox` for managing test environments. There are some pre-configured environments
-that can be used for linting and formatting code when you're preparing contributions to the charm:
+To see all available commands, run:
+```bash
+make help
+```
 
-* ``tox``: Executes all of the basic checks and tests (``lint``, ``unit``, ``static``, and ``coverage-report``).
-* ``tox -e fmt``: Runs formatting using ``black`` and ``isort``.
-* ``tox -e lint``: Runs a range of static code analysis to check the code.
-* ``tox -e static``: Runs other checks such as ``bandit`` for security issues.
+#### Building Artifacts
 
-### Build the rock and charm
+You can build the ROCK OCI image and the charm artifact separately or together.
 
-Use [Rockcraft](https://documentation.ubuntu.com/rockcraft/en/latest/) to create an
-OCI image for the Discourse app, and then upload the image to a MicroK8s registry,
-which stores OCI archives so they can be downloaded and deployed.
+- **Build everything:**  
+  ```bash
+  make build
+  ```
 
-Enable the MicroK8s registry:
+- **Build only the ROCK:**  
+  ```bash
+  make build-rock
+  ```
+
+- **Build only the charm:**  
+  ```bash
+  make build-charm
+  ```
+
+#### Running Tox Environments
+
+You can also run tox test environments individually.
+
+- **Run common tests:**  
+  ```bash
+  make lint  
+  make unit
+  ```
+
+- **Run any other tox environment:** You can run any environment from tox.ini by prefixing it with `tox-`.  
+  ```bash
+  make tox-fmt  
+  make tox-static
+  ```
+
+#### Deploying the Charm
+
+Before deploying for the first time, you need to set up your Juju model.
+
+* **Set up the model (run once):**  
+  ```bash
+  make setup-juju-model
+  ```
+
+* **Deploy the latest local build:** This command will automatically build and publish the necessary artifacts before deploying.  
+  ```bash
+  make deploy
+  ```
+
+#### Running Integration Tests
+
+The most involved workflow is running the integration tests, which build and deploy the charm to a live Juju model before running the test suite.
+
+You can run the full suite with a single command:
 
 ```bash
-microk8s enable registry
+make integration
 ```
 
-The following commands pack the OCI image and push it into
-the MicroK8s registry:
+You can also customize the run by providing variables. For example, to test a specific version and run only a single test function:
 
 ```bash
-cd [project_dir]/discourse_rock
-rockcraft pack
-skopeo --insecure-policy copy --dest-tls-verify=false oci-archive:discourse_1.0_amd64.rock docker://localhost:32000/discourse:latest
+CHARM_VERSION="rev211-rc1" TOX_INTEGRATION_ARGS="-k test_active" make tox-integration
 ```
 
-Build the charm in this git repository using:
+Let's break down what this command does:
 
-```shell
-charmcraft pack
+- **CHARM_VERSION="rev211-rc1"**: By default, the charm version is automatically generated from the current Git state (git describe) to ensure every build is traceable and unique. This override gives you manual control to "tag" a build with a specific identifier, such as a release candidate version, for targeted testing.  
+- **TOX_INTEGRATION_ARGS="-k test_active"**: This passes the argument -k test_active through tox directly to pytest. This tells pytest to only run tests whose names contain "test_active".  
+- **make tox-integration**: This is the core command that orchestrates the entire process:  
+  1. Builds the ROCK OCI image.  
+  2. Builds the charm artifact with the specified CHARM_VERSION.  
+  3. Pushes the ROCK image to the local registry.  
+  4. Deploys the charm to your Juju model.  
+  5. Finally, runs the integration test suite via tox, applying your custom TOX_INTEGRATION_ARGS.
+
+
+#### Debugging Integration test code
+
+You can also easily debug integration test code by specifying the appropriate `TOX_CMD_PREFIX` environment variable for your IDE debugging setup.
+
+For example, given the following default VSCode `launch.json` configuration:
+
+```json
+{
+    "name": "Python Debugger: Remote Attach",
+    "type": "debugpy",
+    "request": "attach",
+    "connect": {
+        "host": "localhost",
+        "port": 5678
+    },
+    "pathMappings": [
+        {
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "."
+        }
+    ]
+},
 ```
 
-### Deploy
+The following command will launch the integration tests, wait for the debugger to attach and then proceed with the test:
 
 ```bash
-# Create a model
-juju add-model charm-dev
-# Enable DEBUG logging
-juju model-config logging-config="<root>=INFO;unit=DEBUG"
-# Deploy the charm (assuming you're on amd64)
-juju deploy ./discourse-k8s_ubuntu-20.04-amd64.charm \
-  --resource discourse-image=localhost:32000/discourse:latest \
+TOX_CMD_PREFIX="python -m debugpy --listen 5678 --wait-for-client -m" make tox-integration
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,21 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# Top-level Makefile
-# Delegates targets to Makefile.docs
-
 # ==============================================================================
-# Macros
+# Project: Discourse K8s Operator
+# This file contains ONLY project-specific configuration.
 # ==============================================================================
 
-# Colors
-NO_COLOR=\033[0m
-CYAN_COLOR=\033[0;36m
-YELLOW_COLOR=\033[0;93m
-RED_COLOR=\033[0;91m
+# Names for this specific charm and its artifacts
+CHARM_NAME 			:= discourse-k8s
+ROCK_NAME 			:= discourse
+OCI_RESOURCE_NAME 	:= discourse-image
 
-msg = @printf '$(CYAN_COLOR)$(1)$(NO_COLOR)\n'
-errmsg = @printf '$(RED_COLOR)Error: $(1)$(NO_COLOR)\n' && exit 1
+ROCK_DIR 			?= discourse_rock
 
 # ==============================================================================
-# Core
+# Makefile common logic
 # ==============================================================================
 
-include Makefile.docs
-
-.PHONY: help 
-help: _list-targets ## Prints all available targets
-
-.PHONY: _list-targets
-_list-targets: ## This collects and prints all targets, ignore internal commands
-	$(call msg,Available targets:)
-	@awk -F'[:#]' '                                               \
-		/^[a-zA-Z0-9._-]+:([^=]|$$)/ {                            \
-			target = $$1;                                         \
-			comment = "";                                         \
-			if (match($$0, /## .*/))                              \
-				comment = substr($$0, RSTART + 3);                \
-			if (target != ".PHONY" && target !~ /^_/ && !seen[target]++) \
-				printf "  make %-20s $(YELLOW_COLOR)# %s$(NO_COLOR)\n", target, comment;    \
-		}' $(MAKEFILE_LIST) | sort
+MAKE_DIR := make
+include $(MAKE_DIR)/common.mk

--- a/make/charm.mk
+++ b/make/charm.mk
@@ -1,0 +1,47 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# ==============================================================================
+# Charm Workflow - Generic logic, managed centrally.
+# ==============================================================================
+
+CHARM_VERSION 			?= $(shell git describe --tags --always --dirty)
+CHARM_PLATFORM 			?= amd64
+# The index of the base in charmcraft.yaml to build
+CHARM_BASE_INDEX 		?= 0
+
+CHARMCRAFT_PACK_CMD 	:= charmcraft pack --bases-index=$(CHARM_BASE_INDEX)
+HAS_YQ := $(shell command -v yq)
+
+ifneq ($(HAS_YQ),)
+    # Read the specified 'run-on' base from charmcraft.yaml to correctly predict the filename.
+    CHARM_BASE_NAME 	:= $(shell yq ".bases[$(CHARM_BASE_INDEX)].run-on[0].name" charmcraft.yaml)
+    CHARM_BASE_CHANNEL 	:= $(shell yq ".bases[$(CHARM_BASE_INDEX)].run-on[0].channel" charmcraft.yaml)
+    CHARM_BASE_STRING 	:= $(CHARM_BASE_NAME)-$(CHARM_BASE_CHANNEL)
+	JUJU_DEPLOY_BASE 	:= $(shell echo $(CHARM_BASE_STRING) | sed 's/-/@/')
+else
+    @$(call errmsg,"yq not found, cannot determine charm base. Filename may be incorrect.")
+endif
+
+CHARM_STATIC_ARTIFACT 	:= $(CHARM_NAME)_$(CHARM_BASE_STRING)-$(CHARM_PLATFORM).charm
+CHARM_DYNAMIC_ARTIFACT 	:= $(CHARM_NAME)_$(CHARM_VERSION)_$(CHARM_BASE_STRING)_$(CHARM_PLATFORM).charm
+
+##@ Charm
+.PHONY: build-charm deploy-charm clean-charm	
+
+build-charm: $(CHARM_DYNAMIC_ARTIFACT) ## Build the charm if it's out of date.
+
+$(CHARM_DYNAMIC_ARTIFACT):
+	@$(call msg,"--> Building Charm artifact: $(CHARM_DYNAMIC_ARTIFACT)...")
+	@echo "$(CHARM_VERSION)" > version
+	@$(CHARMCRAFT_PACK_CMD)
+	@rm -f version
+	@mv $(CHARM_STATIC_ARTIFACT) $(CHARM_DYNAMIC_ARTIFACT)
+
+deploy-charm: $(CHARM_DYNAMIC_ARTIFACT) publish-rock ## Build & publish artifacts, then deploy.
+	@$(call msg,"--> Deploying Charm: $(CHARM_NAME) with ROCK resource: $(ROCK_IMAGE)")
+	@juju deploy -m $(JUJU_MODEL_NAME) ./$(CHARM_DYNAMIC_ARTIFACT) --resource $(OCI_RESOURCE_NAME)=$(ROCK_IMAGE)
+
+clean-charm: ## Remove charm artifacts.
+	@$(call msg,"--> Cleaning charm artifacts...")
+	@rm -f *.charm $(CHARM_OVERRIDE_FILE)

--- a/make/common.mk
+++ b/make/common.mk
@@ -1,0 +1,32 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# ==============================================================================
+# Common Makefile - Generic logic, managed centrally.
+# ==============================================================================
+
+# --- Includes ---
+# Include all the modular workflow files.
+include $(MAKE_DIR)/help.mk
+include $(MAKE_DIR)/rock.mk
+include $(MAKE_DIR)/charm.mk
+include $(MAKE_DIR)/juju.mk
+include $(MAKE_DIR)/tox.mk
+include $(MAKE_DIR)/docs.mk
+
+# Default target when 'make' is called without arguments.
+all: help
+
+.PHONY: all build publish deploy clean test lint unit integration docs
+
+##@ General
+build: build-rock build-charm         		## Build all artifacts (ROCK and Charm).
+publish: publish-rock                 		## Publish all artifacts.
+deploy: deploy-charm                  		## Deploy the charm for local testing.
+clean: clean-rock clean-charm clean-docs    ## Clean up all build artifacts.
+test: tox-unit								## Run unit tests.
+lint: tox-lint docs-check					## Run all linters and documentation checks.	
+unit: tox-unit                    			## Run unit tests.
+integration: tox-integration          		## Deploy the charm, then run integration tests.
+
+

--- a/make/docs.mk
+++ b/make/docs.mk
@@ -1,13 +1,18 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# Minimal makefile for documentation
-#
+# ==============================================================================
+# Documentation specific logic
+# ==============================================================================
+
+##@ Documentation
+.PHONY: docs-check clean-docs vale-sync vale lychee vale-clean
+
 
 # Vale settings
-VALE_DIR ?= .vale
+VALE_DIR 			?= .vale
 PRAECEPTA_CONFIG 	?= .vale.ini
-DOCS_FILES 	?= docs/ README.md CONTRIBUTING.md
+DOCS_FILES 			?= docs/ README.md CONTRIBUTING.md
 
 HAS_VALE			:= $(shell command -v vale;)
 HAS_LYCHEE			:= $(shell command -v lychee;)
@@ -16,11 +21,9 @@ HAS_LYCHEE			:= $(shell command -v lychee;)
 # Docs Targets
 # ==============================================================================
 
-.PHONY: docs-check
-docs-check: vale lychee ## Run all Docs checks
+docs-check: vale lychee ## Run all documentation checks (vale and lychee).
 
-.PHONY: docs-clean
-docs-clean: vale-clean
+clean-docs: vale-clean ## Clean documentation-related artifacts.
 
 # ==============================================================================
 # Dependency Check Targets
@@ -29,14 +32,14 @@ docs-clean: vale-clean
 .PHONY: .check-vale
 .check-vale:
 ifndef HAS_VALE
-	$(call errmsg,'vale' is not installed. Please install it first) \
+	@$(call errmsg,'vale' is not installed. Please install it first) \
 	exit 1;
 endif
 
 .PHONY: .check-lychee
 .check-lychee:
 ifndef HAS_LYCHEE
-	$(call errmsg,'lychee' is not installed. Please install it first) \
+	@$(call errmsg,'lychee' is not installed. Please install it first) \
 	exit 1;
 endif
 
@@ -45,30 +48,26 @@ endif
 # Main Vale Targets
 # ==============================================================================
 
-.PHONY: vale-sync
 vale-sync: ## Download and install external Vale configuration sources
-	$(call msg,--- Syncing Vale styles... ---)
+	@$(call msg,--- Syncing Vale styles... ---)
 	@vale sync
 
-.PHONY: vale
 vale: .check-vale vale-sync ## Run Vale checks on docs
-	$(call msg,--- Running Vale checks on "$(DOCS_FILES)"... ---)
+	@$(call msg,--- Running Vale checks on "$(DOCS_FILES)"... ---)
 	@vale --config=$(PRAECEPTA_CONFIG) $(DOCS_FILES)
 
 # ==============================================================================
 # Main Lychee Targets
 # ==============================================================================
 
-.PHONY: lychee
 lychee: .check-lychee ## Run Lychee checks on docs
-	$(call msg,--- Running lychee checks on "$(LYCHEE_DOCS_FILES)"... ---)
+	@$(call msg,--- Running lychee checks on "$(LYCHEE_DOCS_FILES)"... ---)
 	@lychee $(DOCS_FILES)
 
 # ==============================================================================
 # Helper Targets
 # ==============================================================================
 
-.PHONY: vale-clean
-vale-clean:
-	$(call msg,--- Cleaning downloaded packages and ignored files from "$(VALE_DIR)"... ---)
+vale-clean: ## Clean documentation-related artifacts.
+	@$(call msg,--- Cleaning downloaded packages and ignored files from "$(VALE_DIR)"... ---)
 	@git clean -dfX $(VALE_DIR)

--- a/make/help.mk
+++ b/make/help.mk
@@ -1,0 +1,37 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# ==============================================================================
+# Help Specific logic
+# Contains macros and the self-documenting help target.
+# ==============================================================================
+
+# --- Color & Message Macros ---
+NO_COLOR=\033[0m
+CYAN_COLOR=\033[0;36m
+YELLOW_COLOR=\033[0;93m
+RED_COLOR=\033[0;91m
+
+msg = printf '$(CYAN_COLOR)$(1)$(NO_COLOR)\n'
+warnmsg = printf '$(YELLOW_COLOR)Warning: $(1)$(NO_COLOR)\n'
+errmsg = printf '$(RED_COLOR)Error: $(1)$(NO_COLOR)\n' && exit 1
+
+
+##@ Helpers
+.PHONY: help
+
+help: ## Prints all available, documented targets.
+	@$(call msg,Available targets:)
+	@awk ' \
+		/^##@/ { \
+			sub(/^##@ /, ""); \
+			printf "\n  \033[1m%s\033[0m\n", $$0; \
+		} \
+		/^[a-zA-Z0-9_-]+:.*?##/ { \
+			match($$0, /## .*/); \
+			comment = substr($$0, RSTART + 3); \
+			split($$0, target, ":"); \
+			if (target[1] ~ /^[a-zA-Z0-9_-]+$$/ && target[1] != ".PHONY") { \
+				printf "    make %-20s $(YELLOW_COLOR)# %s$(NO_COLOR)\n", target[1], comment; \
+			} \
+		}' $(MAKEFILE_LIST)

--- a/make/juju.mk
+++ b/make/juju.mk
@@ -1,0 +1,33 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# ==============================================================================
+# Juju Environment Workflow - Generic logic, managed centrally.
+# ==============================================================================
+
+# --- Default Variable Definitions ---
+# These can be overridden in the root Makefile or from the command line.
+JUJU_MODEL_NAME ?= charm-dev
+JUJU_LOGGING_CONFIG ?= "<root>=INFO;unit=DEBUG"
+
+##@ Juju
+.PHONY: setup-juju-model check-microk8s-registry
+
+setup-juju-model: ## Create and configure the Juju model for development.
+	@$(call msg,"--> Setting up Juju model: $(JUJU_MODEL_NAME)...")
+	@juju models | grep -q "^$(JUJU_MODEL_NAME) " || juju add-model $(JUJU_MODEL_NAME)
+	@juju model-config -m $(JUJU_MODEL_NAME) logging-config=$(JUJU_LOGGING_CONFIG)
+
+check-microk8s-registry: ## Check if the MicroK8s registry addon is enabled.
+	@command -v microk8s >/dev/null || \
+		( $(call errmsg,"microk8s command not found. Is MicroK8s installed and in your PATH?") )
+	@command -v yq >/dev/null || \
+		( $(call errmsg,"yq command not found. Please install yq to parse MicroK8s YAML output.") )
+	@microk8s status --wait-ready --format=yaml | \
+		yq '.addons[] | select(.name=="registry") | .status' | grep -qx "enabled" || \
+		( $(call errmsg,"MicroK8s registry is not enabled. Please run 'microk8s enable registry'.") )
+
+print-path:
+	@echo $$PATH
+	@which charmcraft || echo "charmcraft not found"
+	@which microk8s || echo "microk8s not found"

--- a/make/rock.mk
+++ b/make/rock.mk
@@ -1,0 +1,59 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# ==============================================================================
+# ROCK Workflow - Generic logic, managed centrally.
+# ==============================================================================
+
+ROCK_DIR 			?= rock
+DOCKER_REGISTRY 	?= localhost:32000
+
+HAS_YQ := $(shell command -v yq)
+
+ifneq ($(HAS_YQ),)
+    ROCK_VERSION_BASE := $(shell yq '.version // "1.0"' $(ROCK_DIR)/rockcraft.yaml)
+else
+    @$(call errmsg,"yq not found, cannot determine rock base. Filename may be incorrect.")
+endif
+
+ROCK_PLATFORM ?= amd64
+
+# The OCI image tag is DYNAMIC, including the hash for cache-busting.
+ROCK_CONTENT_HASH 	:= $(shell find $(ROCK_DIR) -type f -not -name '*.rock' -print0 | sort -z | xargs -0 cat | sha1sum | cut -c1-7)
+ROCK_IMAGE_TAG 		?= $(ROCK_VERSION_BASE)-$(ROCK_CONTENT_HASH)
+ROCK_STATIC_ARTIFACT := $(ROCK_NAME)_$(ROCK_VERSION_BASE)_$(ROCK_PLATFORM).rock
+ROCK_DYNAMIC_ARTIFACT := $(ROCK_NAME)_$(ROCK_IMAGE_TAG)_$(ROCK_PLATFORM).rock
+ROCK_IMAGE 			:= $(DOCKER_REGISTRY)/$(ROCK_NAME):$(ROCK_IMAGE_TAG)
+
+ROCKCRAFT_PACK_CMD 	:= rockcraft pack
+SKOPEO_ARGS 		?= --insecure-policy copy --dest-tls-verify=false
+SKOPEO_COPY_CMD 	:= skopeo $(SKOPEO_ARGS)
+
+##@ ROCK
+.PHONY: build-rock publish-rock clean-rock
+
+build-rock: $(ROCK_DIR)/$(ROCK_DYNAMIC_ARTIFACT) ## Build the ROCK OCI image.
+
+$(ROCK_DIR)/$(ROCK_DYNAMIC_ARTIFACT):
+	@$(call msg,"--> Building ROCK artifact: $(ROCK_DYNAMIC_ARTIFACT)...")
+	@cd $(ROCK_DIR) && $(ROCKCRAFT_PACK_CMD)
+	@mv $(ROCK_DIR)/$(ROCK_STATIC_ARTIFACT) $(ROCK_DIR)/$(ROCK_DYNAMIC_ARTIFACT)
+
+publish-rock: $(ROCK_DIR)/$(ROCK_DYNAMIC_ARTIFACT) check-microk8s-registry ## Push the ROCK OCI image to the registry, if not already present.
+	@$(call msg,"--> Publishing ROCK: $(ROCK_IMAGE)")
+	@{ \
+		if skopeo --insecure-policy inspect --tls-verify=false docker://$(ROCK_IMAGE) >/dev/null 2>&1; then \
+			$(call warnmsg, Image $(ROCK_IMAGE) already exists in registry, skipping upload); \
+			exit 0; \
+		fi; \
+		$(SKOPEO_COPY_CMD) oci-archive:$(ROCK_DIR)/$(ROCK_DYNAMIC_ARTIFACT) docker://$(ROCK_IMAGE); \
+	}
+
+publish-rock-force: $(ROCK_DIR)/$(ROCK_DYNAMIC_ARTIFACT) check-microk8s-registry ## Force push the ROCK OCI image to the registry.
+	@$(call msg,"--> Force Publishing ROCK: $(ROCK_IMAGE)")
+	microk8s ctr images rm $(ROCK_IMAGE) || true
+	$(SKOPEO_COPY_CMD) oci-archive:$(ROCK_DIR)/$(ROCK_DYNAMIC_ARTIFACT) docker://$(ROCK_IMAGE)
+
+clean-rock: ## Remove ROCK artifacts.
+	@$(call msg,"--> Cleaning ROCK artifacts...")
+	@rm -f $(ROCK_DIR)/*.rock

--- a/make/tox.mk
+++ b/make/tox.mk
@@ -1,0 +1,56 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# ==============================================================================
+# Tox Workflow - Generic logic, managed centrally.
+# ==============================================================================
+
+VENV_DIR ?= .venv
+VENV_PYTHON := $(VENV_DIR)/bin/python
+TOX := $(VENV_DIR)/bin/tox
+
+# Default empty ARGS variables for each explicit tox target.
+# These can be overridden in the root Makefile.
+TOX_LINT_ARGS ?=
+TOX_UNIT_ARGS ?=
+TOX_INTEGRATION_ARGS ?=
+
+INTEGRATION_TEST_ENV ?= \
+	CHARM_FILE=./$(CHARM_DYNAMIC_ARTIFACT) \
+	ROCK_IMAGE=$(ROCK_IMAGE) \
+	OCI_RESOURCE_NAME=$(OCI_RESOURCE_NAME) \
+	JUJU_DEPLOY_BASE=$(JUJU_DEPLOY_BASE)
+
+$(VENV_DIR):
+	@$(call msg,"--> Creating Python virtual environment in $(VENV_DIR)...")
+	@python3 -m venv $(VENV_DIR)
+
+$(TOX): $(VENV_DIR)
+	@$(call msg,"--> Installing tox in virtual environment...")
+	@$(VENV_PYTHON) -m pip install tox
+
+##@ Testing
+.PHONY: lint unit integration
+.PHONY: tox-lint tox-unit tox-integration
+
+tox-lint: $(TOX) ## Run linters using tox.
+	@$(call msg,"--> Running tox environment: lint")
+	@$(TOX) -e lint -- $(TOX_LINT_ARGS)
+
+tox-unit: $(TOX) ## Run unit tests using tox.
+	@$(call msg,"--> Running tox environment: unit")
+	@$(TOX) -e unit -- $(TOX_UNIT_ARGS)
+
+tox-integration: $(TOX) build-charm publish-rock ## Deploy the rock, build the charm, then run integration tests.
+	@$(call msg,"--> Running tox environment: integration")
+	@$(call msg,"    ROCK_IMAGE:'$(ROCK_IMAGE)'  CHARM_FILE:'$(CHARM_DYNAMIC_ARTIFACT)'")
+	$(INTEGRATION_TEST_ENV) $(TOX) -e integration -- $(TOX_INTEGRATION_ARGS)
+
+# This pattern rule allows running any other tox environment.
+# Example: 'make tox-fmt' will run 'tox -e fmt'.
+.PHONY: tox-%
+tox-%: $(TOX)
+	$(eval ENV_UPPER := $(shell echo $* | tr 'a-z-' 'A-Z_'))
+	@$(call msg,"--> Running tox environment: $* $($(ENV_UPPER)_ARGS)")
+	@$(if $($(ENV_UPPER)_ARGS),$(call msg, "    using args from TOX_$(ENV_UPPER)_ARGS: '$($(ENV_UPPER)_ARGS)')")
+	@$(TOX) -e $* -- $($(ENV_UPPER)_ARGS)


### PR DESCRIPTION
### Overview

This pull request introduces a comprehensive `Makefile` system designed to standardize and simplify the local development workflow for this charm. It replaces the current process of following scattered instructions in `CONTRIBUTING.md` and other docs with a single, self-documenting command-line interface.

#### The Problem

Currently, the developer experience can be challenging, especially for new contributors. To build, test, and deploy the charm, a developer needs to:

* Consult multiple documents (`README.md`, `CONTRIBUTING.md`, tutorials).
* Manually run a series of `rockcraft`, `skopeo`, `charmcraft`, and `tox` commands in the correct order.
* Remember specific arguments and flags for each step.
* This process is error-prone, time-consuming, and can vary slightly between our different charm repositories.

#### The Solution: A Unified Workflow

This new system provides a set of simple, consistent `make` commands to handle the entire development lifecycle.

**Key Benefits:**

* **Discoverability:** A developer can run `make help` to see all available commands and what they do.
* **Simplicity:** Complex multi-step processes are now single commands (e.g., `make integration`).
* **Consistency:** The same commands can eventually be used across all our charm repositories.
* **Automation & Reliability:** The Makefiles automatically handle versioning from Git and content hashes. This ensures you are always testing and deploying the exact version of the code you have locally, preventing issues with stale artifacts.
* **Efficiency:** Workflows automatically detect if your artifacts are up-to-date based on file content, skipping unnecessary build steps and saving you time. You won't have to wait for a ROCK build if the correct version is already present.
* **Flexible Testing:** The system gives you full control to run integration tests against specific artifact versions you may have already built locally.

#### This is a Trial Run

This implementation in the `discourse-k8s-operator` is a **proof of concept**. The primary goal is to gather feedback from the team on the usability, command structure, and overall direction of this approach.

The long-term vision is to refine this system and adopt it across all our charm repositories (where it makes sense) to create a standardized, low-friction development environment for everyone.

#### How to Use It

To get started, you can see a full list of available commands and their descriptions by running:

```bash
make help
```

For a detailed guide with common workflow examples, such as running integration tests, please see the updated `CONTRIBUTING.md` file.

We welcome all feedback and ideas for improvement!


### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The changelog is updated.
<!-- Explanation for any unchecked items above -->
