### PR TITLE
Fix versioningTemplate regex for patch version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -52,7 +52,7 @@
         "source:.*discourse/discourse\\.git.*\\n.*source-depth: 1.*\\n.*source-tag: (?<currentValue>.+)"
       ],
       "matchStringsStrategy": "any",
-      "versioningTemplate": "regex:^v?(?<major>\\d{4})\\.(?<minor>\\d{2})\\.(?<patch>\\d+)-latest$"
+      "versioningTemplate": "regex:^v?(?<major>\\d{4})\\.(?<minor>\\d+)\\.(?<patch>\\d+)-latest$"
     }
   ]
 }


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

I just realized that the next tag is v2026.1.0-latest not v2026.01.0-latest. This PR should fix it.

### Rationale

<!-- The reason the change is needed -->

### Juju events changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The changelog is updated.
<!-- Explanation for any unchecked items above -->
