### PR TITLE
Disable jubilant logging for juju.deploy, juju.config and juju.exec

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -218,14 +218,15 @@ def app_fixture(
         base="ubuntu@22.04",
         trust=True,
         config={"profile": "testing"},
+        log=False,
     )
-    juju.deploy("redis-k8s", base="ubuntu@22.04", channel="latest/edge")
+    juju.deploy("redis-k8s", base="ubuntu@22.04", channel="latest/edge", log=False)
     juju.wait(
         lambda status: jubilant.all_active(status, "postgresql-k8s", "redis-k8s"),
         timeout=20 * 60,
     )
 
-    juju.deploy("nginx-ingress-integrator", base="ubuntu@22.04", trust=True)
+    juju.deploy("nginx-ingress-integrator", base="ubuntu@22.04", trust=True, log=False)
 
     juju.deploy(
         charm=charm_file,
@@ -233,6 +234,7 @@ def app_fixture(
         resources=charm_resources,
         config=app_config,
         base=charm_base,
+        log=False,
     )
 
     juju.wait(lambda status: jubilant.all_waiting(status, app_name))
@@ -244,6 +246,7 @@ def app_fixture(
             "plugin_hstore_enable": True,
             "plugin_pg_trgm_enable": True,
         },
+        log=False,
     )
     juju.wait(lambda status: jubilant.all_active(status, "postgresql-k8s"))
 
@@ -265,7 +268,7 @@ def app_fixture(
         f"'set -euo pipefail; echo \"{inline_yaml}\" | {pebble_exec} -- {discourse_rake_command}'"
     )
     logger.info("Enable plugins command: %s", full_command)
-    task = juju.exec(full_command, unit=app_name + "/0")
+    task = juju.exec(full_command, unit=app_name + "/0", log=False)
     logger.info(task.results)
 
     yield types.App(app_name)
@@ -274,14 +277,11 @@ def app_fixture(
 @pytest.fixture(scope="module")
 def setup_saml_config(juju: jubilant.Juju, app: types.App):
     """Set SAML related charm config to enable SAML authentication."""
-    juju.config(app.name, {"force_https": True})
+    juju.config(app.name, {"force_https": True}, log=False)
 
     saml_helper = SamlK8sTestHelper.deploy_saml_idp(juju.model)
     juju.deploy(
-        "saml-integrator",
-        channel="latest/edge",
-        base="ubuntu@22.04",
-        trust=True,
+        "saml-integrator", channel="latest/edge", base="ubuntu@22.04", trust=True, log=False
     )
 
     juju.wait(jubilant.all_agents_idle, timeout=JUJU_WAIT_TIMEOUT)
@@ -294,6 +294,7 @@ def setup_saml_config(juju: jubilant.Juju, app: types.App):
             "entity_id": saml_helper.entity_id,
             "metadata_url": saml_helper.metadata_url,
         },
+        log=False,
     )
     juju.integrate(app.name, "saml-integrator")
     juju.wait(jubilant.all_agents_idle, timeout=JUJU_WAIT_TIMEOUT)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -39,7 +39,7 @@ def test_prom_exporter_is_up(app: types.App, juju: jubilant.Juju):
     status = juju.status()
     assert app.name + "/0" in status.apps[app.name].units
     cmd = f"/usr/bin/curl -m 30 http://localhost:{PROMETHEUS_PORT}/metrics"
-    juju.exec(cmd, unit=app.name + "/0", wait=60)
+    juju.exec(cmd, unit=app.name + "/0", wait=60, log=False)
 
 
 @pytest.mark.abort_on_fail
@@ -86,6 +86,7 @@ def test_s3_conf(app: types.App, juju: jubilant.Juju, s3_address: str | None):
     juju.exec(
         f'echo "{s3_conf["ip_address"]}  {s3_domain}" >> /etc/hosts',
         unit=app.name + "/0",
+        log=False,
     )
 
     logger.info("Injected bucket subdomain in hosts, configuring settings for discourse")
@@ -101,6 +102,7 @@ def test_s3_conf(app: types.App, juju: jubilant.Juju, s3_address: str | None):
             # Default localstack region
             "s3_region": s3_conf["region"],
         },
+        log=False,
     )
     juju.wait(jubilant.all_active)
 
@@ -150,6 +152,7 @@ def test_s3_conf(app: types.App, juju: jubilant.Juju, s3_address: str | None):
             # Default localstack region
             "s3_region": "",
         },
+        log=False,
     )
     juju.wait(jubilant.all_active)
 

--- a/tests/integration/test_db_migration.py
+++ b/tests/integration/test_db_migration.py
@@ -37,6 +37,7 @@ def test_db_migration(
         base="ubuntu@22.04",
         trust=True,
         config={"profile": "testing"},
+        log=False,
     )
     juju.wait(lambda status: status.apps[pg_app_name].is_active, timeout=JUJU_WAIT_TIMEOUT)
     juju.config(
@@ -45,6 +46,7 @@ def test_db_migration(
             "plugin_hstore_enable": True,
             "plugin_pg_trgm_enable": True,
         },
+        log=False,
     )
     juju.wait(lambda status: status.apps[pg_app_name].is_active)
     task = juju.run(pg_app_name + "/0", "get-password", {"username": "operator"})
@@ -94,10 +96,10 @@ def test_db_migration(
         "Discourse v3.3.0 git version does not match with the database version"
     )
 
-    juju.deploy("redis-k8s", base="ubuntu@22.04", channel="latest/edge")
+    juju.deploy("redis-k8s", base="ubuntu@22.04", channel="latest/edge", log=False)
     juju.wait(lambda status: status.apps["redis-k8s"].is_active)
 
-    juju.deploy("nginx-ingress-integrator", base="ubuntu@22.04", trust=True)
+    juju.deploy("nginx-ingress-integrator", base="ubuntu@22.04", trust=True, log=False)
 
     discourse_app_name = "discourse-k8s"
     juju.deploy(
@@ -105,6 +107,7 @@ def test_db_migration(
         app=discourse_app_name,
         resources=charm_resources,
         base=charm_base,
+        log=False,
     )
     juju.wait(lambda status: status.apps[discourse_app_name].is_waiting)
 

--- a/tests/integration/test_oauth.py
+++ b/tests/integration/test_oauth.py
@@ -67,9 +67,12 @@ def test_oauth_integration(app: types.App, juju: jubilant.Juju):
         app=any_app_name,
         channel="beta",
         config={"src-overwrite": json.dumps(any_charm_src_overwrite), "python-packages": "ops"},
+        log=False,
     )
 
-    juju.config(app.name, {"force_https": True, "external_hostname": "test.discourse.com"})
+    juju.config(
+        app.name, {"force_https": True, "external_hostname": "test.discourse.com"}, log=False
+    )
 
     juju.integrate(app.name, f"{any_app_name}:oauth")
 


### PR DESCRIPTION
## Summary

Disable jubilant logging for all `juju.deploy()`, `juju.config()` and `juju.exec()` calls in integration tests by adding `log=False`.

## Changes

- `tests/integration/test_oauth.py`
- `tests/integration/test_db_migration.py`
- `tests/integration/test_charm.py`
- `tests/integration/conftest.py`