### PR TITLE
fix: Disable deploy logs in Jubilant

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -180,7 +180,9 @@ def charm_file(metadata: Dict[str, Any], pytestconfig: pytest.Config):
         return
 
     try:
-        subprocess.run(["charmcraft", "pack"], check=True, capture_output=True, text=True)  # nosec B603, B607
+        subprocess.run(
+            ["charmcraft", "pack"], check=True, capture_output=True, text=True
+        )  # nosec B603, B607
     except subprocess.CalledProcessError as exc:
         raise OSError(f"Error packing charm: {exc}; Stderr:\n{exc.stderr}") from None
 
@@ -188,7 +190,9 @@ def charm_file(metadata: Dict[str, Any], pytestconfig: pytest.Config):
     charm_path = pathlib.Path(__file__).parent.parent.parent
     charms = [p.absolute() for p in charm_path.glob(f"{app_name}_*.charm")]
     assert charms, f"{app_name} .charm file not found"
-    assert len(charms) == 1, f"{app_name} has more than one .charm file, unsure which to use"
+    assert (
+        len(charms) == 1
+    ), f"{app_name} has more than one .charm file, unsure which to use"
     yield str(charms[0])
 
 
@@ -218,14 +222,15 @@ def app_fixture(
         base="ubuntu@22.04",
         trust=True,
         config={"profile": "testing"},
+        log=False,
     )
-    juju.deploy("redis-k8s", base="ubuntu@22.04", channel="latest/edge")
+    juju.deploy("redis-k8s", base="ubuntu@22.04", channel="latest/edge", log=False)
     juju.wait(
         lambda status: jubilant.all_active(status, "postgresql-k8s", "redis-k8s"),
         timeout=20 * 60,
     )
 
-    juju.deploy("nginx-ingress-integrator", base="ubuntu@22.04", trust=True)
+    juju.deploy("nginx-ingress-integrator", base="ubuntu@22.04", trust=True, log=False)
 
     juju.deploy(
         charm=charm_file,
@@ -233,6 +238,7 @@ def app_fixture(
         resources=charm_resources,
         config=app_config,
         base=charm_base,
+        log=False,
     )
 
     juju.wait(lambda status: jubilant.all_waiting(status, app_name))
@@ -255,7 +261,9 @@ def app_fixture(
 
     # Enable plugins calling rake site_settings:import in one of the units.
     inline_yaml = "\n".join(f"{plugin}_enabled: true" for plugin in ENABLED_PLUGINS)
-    discourse_rake_command = "/srv/discourse/app/bin/bundle exec rake site_settings:import "
+    discourse_rake_command = (
+        "/srv/discourse/app/bin/bundle exec rake site_settings:import "
+    )
     pebble_exec = (
         "PEBBLE_SOCKET=/charm/containers/discourse/pebble.socket "
         "pebble exec --user=_daemon_ --context=discourse -w=/srv/discourse/app"
@@ -282,6 +290,7 @@ def setup_saml_config(juju: jubilant.Juju, app: types.App):
         channel="latest/edge",
         base="ubuntu@22.04",
         trust=True,
+        log=False,
     )
 
     juju.wait(jubilant.all_agents_idle, timeout=JUJU_WAIT_TIMEOUT)
@@ -314,7 +323,9 @@ def admin_credentials_fixture(juju: jubilant.Juju, app: types.App) -> types.Cred
 
 
 @pytest.fixture(scope="module", name="admin_api_key")
-def admin_api_key_fixture(admin_credentials: types.Credentials, discourse_address: str) -> str:
+def admin_api_key_fixture(
+    admin_credentials: types.Credentials, discourse_address: str
+) -> str:
     """Admin user API key"""
     with requests.session() as session:
         # Get CSRF token

--- a/tests/integration/test_db_migration.py
+++ b/tests/integration/test_db_migration.py
@@ -37,8 +37,11 @@ def test_db_migration(
         base="ubuntu@22.04",
         trust=True,
         config={"profile": "testing"},
+        log=False,
     )
-    juju.wait(lambda status: status.apps[pg_app_name].is_active, timeout=JUJU_WAIT_TIMEOUT)
+    juju.wait(
+        lambda status: status.apps[pg_app_name].is_active, timeout=JUJU_WAIT_TIMEOUT
+    )
     juju.config(
         pg_app_name,
         {
@@ -90,14 +93,14 @@ def test_db_migration(
               -c 'SELECT git_version FROM schema_migration_details LIMIT 1;'",
         stdin=db_pass + "\n",
     )
-    assert "5bbdc8a813caf55ab3147ac65b5ffafb5e0aab90" in latest_git_version, (
-        "Discourse v3.3.0 git version does not match with the database version"
-    )
+    assert (
+        "5bbdc8a813caf55ab3147ac65b5ffafb5e0aab90" in latest_git_version
+    ), "Discourse v3.3.0 git version does not match with the database version"
 
-    juju.deploy("redis-k8s", base="ubuntu@22.04", channel="latest/edge")
+    juju.deploy("redis-k8s", base="ubuntu@22.04", channel="latest/edge", log=False)
     juju.wait(lambda status: status.apps["redis-k8s"].is_active)
 
-    juju.deploy("nginx-ingress-integrator", base="ubuntu@22.04", trust=True)
+    juju.deploy("nginx-ingress-integrator", base="ubuntu@22.04", trust=True, log=False)
 
     discourse_app_name = "discourse-k8s"
     juju.deploy(
@@ -105,6 +108,7 @@ def test_db_migration(
         app=discourse_app_name,
         resources=charm_resources,
         base=charm_base,
+        log=False,
     )
     juju.wait(lambda status: status.apps[discourse_app_name].is_waiting)
 

--- a/tests/integration/test_oauth.py
+++ b/tests/integration/test_oauth.py
@@ -24,7 +24,8 @@ def test_oauth_integration(app: types.App, juju: jubilant.Juju):
     """
     any_app_name = "any-oauth"
     any_charm_src_overwrite = {
-        "any_charm.py": textwrap.dedent("""\
+        "any_charm.py": textwrap.dedent(
+            """\
         from any_charm_base import AnyCharmBase
         from ops.model import ActiveStatus
         import json
@@ -59,17 +60,24 @@ def test_oauth_integration(app: types.App, juju: jubilant.Juju):
                 }
                 event.relation.data[self.app].update(relation_data)
                 self.unit.status = ActiveStatus()
-        """),
+        """
+        ),
     }
 
     juju.deploy(
         "any-charm",
         app=any_app_name,
         channel="beta",
-        config={"src-overwrite": json.dumps(any_charm_src_overwrite), "python-packages": "ops"},
+        config={
+            "src-overwrite": json.dumps(any_charm_src_overwrite),
+            "python-packages": "ops",
+        },
+        log=False,
     )
 
-    juju.config(app.name, {"force_https": True, "external_hostname": "test.discourse.com"})
+    juju.config(
+        app.name, {"force_https": True, "external_hostname": "test.discourse.com"}
+    )
 
     juju.integrate(app.name, f"{any_app_name}:oauth")
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

Set jubilant deploy logs to False

### Rationale

jubilant deploy may contain sensitive commands

### Juju events changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The changelog is updated.
<!-- Explanation for any unchecked items above -->

Testing code changes only.
