### PR TITLE
chore(ci): fix CI broken by org-level read-only GITHUB_TOKEN default

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,7 +27,7 @@ Please, provide some information about your PR before proceeding.
 
 ### Checklist
 
-- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
+- [ ] The [charm style guide](https://documentation.ubuntu.com/ops/latest/howto/write-and-structure-charm-code/) was applied
 - [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
 - [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
 - [ ] The documentation for charmhub is updated.

--- a/.github/workflows/auto_update_libs.yaml
+++ b/.github/workflows/auto_update_libs.yaml
@@ -7,4 +7,8 @@ on:
 jobs:
   auto-update-libs:
     uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     secrets: inherit

--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -6,4 +6,6 @@ on:
 jobs:
   bot_pr_approval:
     uses: canonical/operator-workflows/.github/workflows/bot_pr_approval.yaml@main
+    permissions:
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -9,4 +9,7 @@ on:
 jobs:
   comment-on-pr:
     uses: canonical/operator-workflows/.github/workflows/comment.yaml@main
+    permissions:
+      pull-requests: write
+      actions: read
     secrets: inherit

--- a/.github/workflows/comment_contributing.yaml
+++ b/.github/workflows/comment_contributing.yaml
@@ -10,4 +10,6 @@ on:
 jobs:
   comment-on-pr:
     uses: canonical/operator-workflows/.github/workflows/comment_contributing.yaml@main
+    permissions:
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,4 +9,6 @@ on:
 jobs:
   docs-checks:
     uses: canonical/operator-workflows/.github/workflows/docs.yaml@main
+    permissions:
+      contents: read
     secrets: inherit

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,7 +12,14 @@ jobs:
     permissions:
       contents: read
       packages: write
-    secrets: inherit
+    secrets:
+      CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
+      DISCOURSE_API_KEY: ${{ secrets.DISCOURSE_API_KEY }}
+      DISCOURSE_API_USERNAME: ${{ secrets.DISCOURSE_API_USERNAME }}
+      JIRA_URL: ${{ secrets.JIRA_URL }}
+      REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+      TEST_SAML_EMAIL: ${{ secrets.TEST_SAML_EMAIL }}
+      TEST_SAML_PASSWORD: ${{ secrets.TEST_SAML_PASSWORD }}
     with:
       pre-run-script: s3-installation.sh
       trivy-image-config: "trivy.yaml"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    permissions:
+      contents: read
+      packages: write
     secrets: inherit
     with:
       pre-run-script: s3-installation.sh
@@ -25,3 +28,5 @@ jobs:
     needs:
     - integration-tests
     uses: canonical/operator-workflows/.github/workflows/allure_report.yaml@main
+    permissions:
+      contents: write

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,14 +12,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    secrets:
-      CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
-      DISCOURSE_API_KEY: ${{ secrets.DISCOURSE_API_KEY }}
-      DISCOURSE_API_USERNAME: ${{ secrets.DISCOURSE_API_USERNAME }}
-      JIRA_URL: ${{ secrets.JIRA_URL }}
-      REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
-      TEST_SAML_EMAIL: ${{ secrets.TEST_SAML_EMAIL }}
-      TEST_SAML_PASSWORD: ${{ secrets.TEST_SAML_PASSWORD }}
+    secrets: inherit
     with:
       pre-run-script: s3-installation.sh
       trivy-image-config: "trivy.yaml"

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -20,6 +20,8 @@ on:
 jobs:
   promote-charm:
     uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@main
+    permissions:
+      contents: write
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -12,4 +12,5 @@ jobs:
     permissions:
       actions: read
       contents: write
+      packages: write
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   unit-tests:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write
     secrets: inherit
     with:
       self-hosted-runner: true

--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -1,6 +1,8 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+## TEMP CHANGE
+
 name: discourse
 summary: Discourse rock
 description: Discourse OCI image for the Discourse charm

--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -1,8 +1,6 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-## TEMP CHANGE
-
 name: discourse
 summary: Discourse rock
 description: Discourse OCI image for the Discourse charm

--- a/docs/how-to/backup-and-restore.md
+++ b/docs/how-to/backup-and-restore.md
@@ -21,7 +21,7 @@ backups (see [how to configure S3](./configure-s3.md)). If  `s3_backup_bucket` i
 the backups will be placed in one of the workload containers,
 in the path `/srv/discourse/app/public/backups/`. This will make HA deployments work incorrectly.
 Besides, it will be necessary to get the backup files and put them in a more secure place,
-using Discourse admin interface or [`juju scp`](https://juju.is/docs/juju/juju-scp).
+using Discourse admin interface or [`juju scp`](https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/scp/).
 
 A backup can be made by a site administrator using the web interface. See
 [Create, download, and restore a backup of your Discourse database](https://meta.discourse.org/t/create-download-and-restore-a-backup-of-your-discourse-database/122710/1)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ Kubernetes offerings.
 
 | | |
 |--|--|
-|  [Tutorials](https://charmhub.io/discourse-k8s/docs/tutorial)</br>  Get started - a hands-on introduction to using the Charmed Discourse operator for new users </br> |  [How-to guides](https://charmhub.io/discourse-k8s/docs/how-to-landing-page) </br> Step-by-step guides covering key operations and common tasks | 
+|  [Tutorials](https://charmhub.io/discourse-k8s/docs/tutorial)</br>  Get started - a hands-on introduction to using the Charmed Discourse operator for new users </br> |  [How-to guides](https://charmhub.io/discourse-k8s/docs/how-to) </br> Step-by-step guides covering key operations and common tasks | 
 | [Reference](reference/index.md) </br> Technical information - specifications, APIs, architecture | [Explanation](https://charmhub.io/discourse-k8s/docs/explanation-security) </br> Concepts - discussion and clarification of key topics  |
 
 ## Contributing to this documentation

--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -2,4 +2,4 @@
 
 See [Actions](https://charmhub.io/discourse-k8s/actions).
 
-> Read more about actions in the Juju docs: [Action](https://juju.is/docs/juju/action)
+> Read more about actions in the Juju docs: [Action](https://documentation.ubuntu.com/juju/3.6/reference/action/)

--- a/docs/reference/charm-architecture.md
+++ b/docs/reference/charm-architecture.md
@@ -2,7 +2,7 @@
 
 At its core, [Discourse](https://www.discourse.org/) is a [Ruby on Rails](https://rubyonrails.org/) application that integrates with [PostgreSQL](https://www.postgresql.org/) and [Redis](https://redis.io/).
 
-The charm design leverages the [sidecar](https://kubernetes.io/blog/2015/06/the-distributed-system-toolkit-patterns/#example-1-sidecar-containers) pattern to allow multiple containers in each pod with [Pebble](https://juju.is/docs/sdk/pebble) running as the workload container’s entrypoint.
+The charm design leverages the [sidecar](https://kubernetes.io/blog/2015/06/the-distributed-system-toolkit-patterns/#example-1-sidecar-containers) pattern to allow multiple containers in each pod with [Pebble](https://documentation.ubuntu.com/ops/latest/reference/pebble/) running as the workload container’s entrypoint.
 
 Pebble is a lightweight, API-driven process supervisor that is responsible for configuring processes to run in a container and controlling those processes throughout the workload lifecycle.
 
@@ -84,7 +84,7 @@ The workload that this container is running is defined in the [Discourse `rockcr
 
 The OCI image is built using [Rockcraft](https://canonical-rockcraft.readthedocs-hosted.com) and defined in the [`rockcraft.yaml` file](https://github.com/canonical/discourse-k8s-operator/blob/main/discourse_rock/rockcraft.yaml) in the charm repository. It is then published to [Charmhub](https://charmhub.io/), the official repository for charms.
 
-This is done by publishing a resource to Charmhub as described in the [Juju SDK How-to guides](https://juju.is/docs/sdk/publishing).
+This is done by publishing a resource to Charmhub as described in the [Ops guide for publishing charms](https://documentation.ubuntu.com/ops/latest/howto/publish-your-charm-on-charmhub/).
 
 ## Integrations
 
@@ -94,7 +94,7 @@ This section provides information about the integrations.
 
 The Discourse charm also supports being integrated with [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/#what-is-ingress) by using [NGINX Ingress Integrator](https://charmhub.io/nginx-ingress-integrator/).
 
-In this case, an existing Ingress controller is required. For more information, see [Adding the Ingress Relation to a Charm](https://charmhub.io/nginx-ingress-integrator/docs/add-the-nginx-route-relation).
+In this case, an existing Ingress controller is required. For more information, see [NGINX Ingress Integrator](https://charmhub.io/nginx-ingress-integrator).
 
 ### PostgreSQL
 
@@ -115,7 +115,7 @@ Prometheus is an open-source systems monitoring and alerting toolkit with a dime
 
 ## Juju events
 
-Accordingly to the [Juju SDK](https://juju.is/docs/sdk/event): "an event is a data structure that encapsulates part of the execution context of a charm".
+Accordingly to the [Ops framework event reference](https://documentation.ubuntu.com/ops/latest/reference/ops/#ops.EventBase): "an event is a data structure that encapsulates part of the execution context of a charm".
 
 For this charm, the following events are observed:
 
@@ -133,7 +133,7 @@ For this charm, the following events are observed:
 
 The `src/charm.py` is the default entry point for a charm and has the DiscourseCharm Python class which inherits from CharmBase.
 
-CharmBase is the base class from which all Charms are formed, defined by [Ops](https://juju.is/docs/sdk/ops) (Python framework for developing charms).
+CharmBase is the base class from which all Charms are formed, defined by [Ops](https://documentation.ubuntu.com/ops/latest/reference/ops/) (Python framework for developing charms).
 
 See more information in [Charm](https://documentation.ubuntu.com/juju/3.6/howto/manage-charms/#build-a-charm).
 

--- a/docs/reference/configurations.md
+++ b/docs/reference/configurations.md
@@ -2,4 +2,4 @@
 
 See [Configurations](https://charmhub.io/discourse-k8s/configure).
 
-> Read more about configurations in the Juju docs: [Configuration](https://juju.is/docs/juju/configuration)
+> Read more about configurations in the Juju docs: [Configuration](https://documentation.ubuntu.com/juju/3.6/reference/configuration/)


### PR DESCRIPTION
### Overview

Fixes all CI failures caused by the canonical org switching the default `GITHUB_TOKEN` permissions to read-only, and broken documentation links from the juju.is → documentation.ubuntu.com RTD migration.

### Rationale

Three issues were breaking CI:

1. **Missing `GITHUB_TOKEN` permissions** — the org-level default is now read-only. Each caller workflow must explicitly grant the permissions required by the reusable workflow it calls (documented in [canonical/operator-workflows#1014](https://github.com/canonical/operator-workflows/pull/1014)).

2. **Broken documentation links** — `juju.is/docs/*` has migrated to `documentation.ubuntu.com/juju` and `documentation.ubuntu.com/ops`.

3. **Stale `INTEGRATION_TEST_ARGS` secret** — the upstream `integration_test.yaml` reusable workflow now explicitly rejects this deprecated secret (it can leak into Allure reports). The secret has been deleted from repo settings.

### Juju events changes

None.

### Module changes

None.

### Library changes

None.

### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/ops/latest/howto/write-and-structure-charm-code/) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The changelog is updated.

<!-- CI/infra-only change: style guide, ISD054, charmhub docs and changelog not applicable -->
