### PR TITLE
fix: restrict Discourse updates to patch versions only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,8 +37,7 @@
         "source:.*discourse/discourse\\.git.*\\n.*source-depth: 1.*\\n.*source-tag: (?<currentValue>.+)"
       ],
       "matchStringsStrategy": "any",
-      "versioningTemplate": "regex:^v?(?<major>\\d{4})\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "matchUpdateTypes": ["patch"]
+      "versioningTemplate": "regex:^v?(?<major>\\d{4})\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
     },
     {
       "customType": "regex",
@@ -83,6 +82,16 @@
       "matchUpdateTypes": [
         "major",
         "minor",
+        "patch"
+      ]
+    },
+    {
+      "description": "Allow only patch updates for Discourse workload",
+      "enabled": true,
+      "matchDepNames": [
+        "discourse/discourse"
+      ],
+      "matchUpdateTypes": [
         "patch"
       ]
     }


### PR DESCRIPTION
<!-- Applicable spec: <link> -->

### Overview

Fix the renovate config by moving the constraint on the discourse updates applying to patches only to the proper location.

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/ops/latest/howto/write-and-structure-charm-code/) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The changelog is updated.
<!-- Explanation for any unchecked items above -->

Closes #452