### PR TITLE
fix: pin pnpm to exact version in rock overlay install

### DIFF
--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -52,7 +52,7 @@ parts:
       $CRAFT_OVERLAY/usr/bin/node $CRAFT_OVERLAY/usr/bin/npm install --verbose --prefix $CRAFT_OVERLAY/usr/local/ --global terser
       $CRAFT_OVERLAY/usr/bin/node $CRAFT_OVERLAY/usr/bin/npm install --verbose --prefix $CRAFT_OVERLAY/usr/local/ --global uglify-js
       $CRAFT_OVERLAY/usr/bin/node $CRAFT_OVERLAY/usr/bin/npm install --verbose --prefix $CRAFT_OVERLAY/usr/local/ --global svgo
-      $CRAFT_OVERLAY/usr/bin/node $CRAFT_OVERLAY/usr/bin/npm install --verbose --prefix $CRAFT_OVERLAY/usr/local/ --global pnpm@10
+      $CRAFT_OVERLAY/usr/bin/node $CRAFT_OVERLAY/usr/bin/npm install --verbose --prefix $CRAFT_OVERLAY/usr/local/ --global pnpm@${PNPM_VERSION}
       ruby_install_uri="https://github.com/postmodern/ruby-install/releases/download/v${RUBY_INSTALL_VERSION}/ruby-install-${RUBY_INSTALL_VERSION}.tar.gz"
       curl -fLO $ruby_install_uri
       tar -xzvf ruby-install-${RUBY_INSTALL_VERSION}.tar.gz


### PR DESCRIPTION
The rock's global pnpm install used `pnpm@10` (unpinned) while `PNPM_VERSION=10.28.0` was already defined and correctly used by the actual install script.

At RUNTIME, Discourse detects any mismatch and attemps to self-install the expected pnpm version. Tests and overall CI passed without issue at the time of the initial PR since pnpm@10 resolved to 10.28.0 and no self-install was triggered during test runs.

However, the moment a new 10.X version was released, the next runtime of Discourse detected  the version mismatch which caused pnpm to attempt a runtime self-install of `pnpm@10.28.0` during `rake db:migrate` which hangs and fails.

Fix: use `pnpm@${PNPM_VERSION}` so both install paths stay in sync.