### PR TITLE
Fix wrong renovate upgrade to v2026.1.4

### DIFF
--- a/discourse_rock/rockcraft.yaml
+++ b/discourse_rock/rockcraft.yaml
@@ -65,7 +65,7 @@ parts:
     plugin: dump
     source: https://github.com/discourse/discourse.git
     source-depth: 1
-    source-tag: v2026.5.0
+    source-tag: v2026.1.4
     source-type: git
     override-build: |
       craftctl default


### PR DESCRIPTION
An old PR (https://github.com/canonical/discourse-k8s-operator/pull/415) from renovate was auto-merged. However, it was updating Discourse to a more recent version that lied outside the current ESR version. 

More recent renovate configuration should prevent that, however this PR has existed for over 5 months and did not include this check.