### PR TITLE
chore: Add tag-prefix to promote

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -27,4 +27,5 @@ jobs:
       destination-channel: ${{ github.event.inputs.destination-channel }}
       base-channel: "22.04"
       doc-automation-disabled: false
+      tag-prefix: discourse-k8s
     secrets: inherit


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->

Add tag-prefix to the promote workflow. As the tags are now named `discourse-k8s-rev<number>`, the current promote fails without the tag prefix.

### Rationale

<!-- The reason the change is needed -->

### Juju events changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/ops/latest/howto/write-and-structure-charm-code/) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The changelog is updated.
<!-- Explanation for any unchecked items above -->
