### PR TITLE
fix: explicitly block Discourse major/minor renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -86,6 +86,17 @@
       ]
     },
     {
+      "description": "Disable major and minor updates for Discourse workload - only patch versions allowed within the current ESR",
+      "enabled": false,
+      "matchDepNames": [
+        "discourse/discourse"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
       "description": "Allow only patch updates for Discourse workload",
       "enabled": true,
       "matchDepNames": [


### PR DESCRIPTION
## Problem

Renovate has been opening PRs to update the Discourse workload to minor versions (e.g. v2026.1.4 → v2026.6.0, see #466), despite prior attempts to restrict this.

Two bugs were compounding:
1. The `matchFiles: ["rockcraft.yaml"]` rule never matched because the file is at `discourse_rock/rockcraft.yaml`,  Renovate path matching is relative to repo root.
2. Adding `enabled: true` for `patch` updates does **not** implicitly disable `minor`, Renovate package rules are additive.

## Fix

Add an explicit `enabled: false` packageRule scoped to `matchDepNames: ["discourse/discourse"]` with `matchUpdateTypes: ["major", "minor"]`.

## Validation

Confirmed with a local Renovate dry-run (`--dry-run=full --platform=local`):
- **Old config**: Renovate queued the v2026.6.0 minor update and processed the `renovate/discourse-discourse-2026.x` branch
- **New config**: The update is filtered out before any branch processing, no PR would be created

Closes #466