### PR TITLE
fix: use allowedVersions to constrain Discourse to current ESR series

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -86,6 +86,17 @@
       ]
     },
     {
+      "description": "Disable major and minor updates for Discourse workload - only patch versions allowed within the current ESR",
+      "enabled": false,
+      "matchDepNames": [
+        "discourse/discourse"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
       "description": "Allow only patch updates for Discourse workload",
       "enabled": true,
       "matchDepNames": [


### PR DESCRIPTION
## Problem

After the previous fix (#470), minor Discourse updates are blocked — but Renovate still wasn't proposing `v2026.1.5`. 

Root cause: Renovate resolves versions by picking the **globally latest tag** (`v2026.6.0`) as its single update candidate. It classifies that as a `minor` update, finds it's blocked, and stops — never surfacing `v2026.1.5` as a separate patch candidate.

## Fix

Replace the two separate enable/disable `matchUpdateTypes` rules with a single `allowedVersions: "/^v2026\.1\./"` constraint on `discourse/discourse`. This tells Renovate to only consider versions in the `2026.1.x` series, forcing it to find the latest patch within that series.

**When upgrading to a new ESR**, update both:
- `discourse_rock/rockcraft.yaml` → `source-tag`
- `renovate.json` → `allowedVersions` pattern

## Validation

Local dry-run with `--dry-run=full --platform=local`:

| Config | Proposed update |
|---|---|
| Before | `v2026.6.0` (minor) → blocked, nothing created |
| After | `v2026.1.5` (patch) → correctly proposed |