### PR TITLE
fix: constrain Discourse renovate updates to current ESR patch series

### DIFF
--- a/.agents/skills/upgrade-discourse-workload/SKILL.md
+++ b/.agents/skills/upgrade-discourse-workload/SKILL.md
@@ -40,7 +40,7 @@ Run all scripts regardless of bump size — do not pre-judge scope.
 
 ---
 
-## §1 — Update `source-tag`
+## §1 — Update `source-tag` and `renovate.json`
 
 Edit `discourse_rock/rockcraft.yaml`:
 
@@ -48,6 +48,16 @@ Edit `discourse_rock/rockcraft.yaml`:
   discourse:
     source-tag: <NEW_TAG>
 ```
+
+If the **minor version changed** (e.g. `v2026.1.x` → `v2026.2.x`), also update `renovate.json` so Renovate auto-proposes future patches within the new series:
+
+```json
+{
+  "allowedVersions": "/^v<YEAR>.<NEW_MINOR>\./"
+}
+```
+
+Find this rule by `matchDepNames: ["discourse/discourse"]` in `packageRules`.
 
 ---
 
@@ -187,6 +197,7 @@ Apply the changes and check `.trivyignore` per `references/guide-db-migration.md
 ## Completion checklist
 
 - [ ] `source-tag` updated in `rockcraft.yaml`
+- [ ] `allowedVersions` in `renovate.json` updated to match new minor series (if minor version changed)
 - [ ] `NODE_VERSION`, `RUBY_VERSION`, `PNPM_VERSION`, bundler version updated if needed
 - [ ] All plugin `source-commit` values updated
 - [ ] `db_migrations.patch` targets the correct file for the new version

--- a/renovate.json
+++ b/renovate.json
@@ -86,24 +86,10 @@
       ]
     },
     {
-      "description": "Disable major and minor updates for Discourse workload - only patch versions allowed within the current ESR",
-      "enabled": false,
+      "description": "Restrict Discourse to current ESR patch series only - update allowedVersions when intentionally upgrading ESR",
+      "allowedVersions": "/^v2026\\.1\\./",
       "matchDepNames": [
         "discourse/discourse"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ]
-    },
-    {
-      "description": "Allow only patch updates for Discourse workload",
-      "enabled": true,
-      "matchDepNames": [
-        "discourse/discourse"
-      ],
-      "matchUpdateTypes": [
-        "patch"
       ]
     }
   ],


### PR DESCRIPTION
Renovate was proposing minor Discourse version bumps (e.g. v2026.1.4 → v2026.6.0) and, after blocking those, stopped proposing patch updates entirely.

**Root cause:** Renovate picks the globally latest tag as its update candidate. Once minor was blocked, nothing was proposed — `v2026.1.5` was never surfaced.

**Fix:** Replace the two discourse `packageRules` with a single `allowedVersions: "/^v2026\.1\./"` constraint, restricting Renovate's lookup to the current ESR patch series.

Also adds a reminder to the upgrade-discourse agent skill to update `allowedVersions` whenever the minor version changes.

> When upgrading to a new ESR: update `source-tag` in `rockcraft.yaml` **and** `allowedVersions` in `renovate.json`.