### PR TITLE
chore: update charm-ci to v0.0.1-alpha.10

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   integration-test:
-    uses: canonical/charm-ci/.github/workflows/integration-test.yml@v0.0.1-alpha.9
+    uses: canonical/charm-ci/.github/workflows/integration-test.yml@v0.0.1-alpha.10
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    uses: canonical/charm-ci/.github/workflows/publish-artifacts.yml@v0.0.1-alpha.9
+    uses: canonical/charm-ci/.github/workflows/publish-artifacts.yml@v0.0.1-alpha.10
     permissions:
       actions: read
       contents: write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ integration = [
   "bs4",
   "debugpy",
   "jubilant==1.11.0",
-  "opcli @ git+https://github.com/canonical/charm-ci.git@v0.0.1-alpha.4 ; python_version >= '3.12'",
+  "opcli @ git+https://github.com/canonical/charm-ci.git@v0.0.1-alpha.10 ; python_version >= '3.12'",
   "protobuf==7.35.1",
   "psycopg2-binary",
   "pytest",

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ integration = [
     { name = "bs4" },
     { name = "debugpy" },
     { name = "jubilant", specifier = "==1.11.0" },
-    { name = "opcli", marker = "python_full_version >= '3.12'", git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.4" },
+    { name = "opcli", marker = "python_full_version >= '3.12'", git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.10" },
     { name = "protobuf", specifier = "==7.35.1" },
     { name = "psycopg2-binary" },
     { name = "pytest" },
@@ -1271,8 +1271,8 @@ wheels = [
 
 [[package]]
 name = "opcli"
-version = "0.0.1a2"
-source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.4#b4788978c987440a24360f3fb7cb879961ddb4c5" }
+version = "0.0.1a10"
+source = { git = "https://github.com/canonical/charm-ci.git?rev=v0.0.1-alpha.10#f0746f4dab15ea08354d38024b188b38576b944a" }
 dependencies = [
     { name = "pydantic" },
     { name = "ruamel-yaml" },


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->

Upgrade charm-ci

### Rationale

<!-- The reason the change is needed -->

### Juju events changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/ops/latest/howto/write-and-structure-charm-code/) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The changelog is updated.
<!-- Explanation for any unchecked items above -->
