### PR TITLE
docs: fix broken postgresql-k8s backup/restore links

### DIFF
--- a/docs/how-to/backup-and-restore.md
+++ b/docs/how-to/backup-and-restore.md
@@ -37,15 +37,15 @@ to backup the database.
 
 This can be easily done with [Charmed PostgreSQL](https://charmhub.io/postgresql) and [Charmed PostgreSQL K8s](https://charmhub.io/postgresql-k8s).
 See [How to create and list backups in Charmed PostgreSQL](https://canonical-charmed-postgresql.readthedocs-hosted.com/14/how-to/back-up-and-restore/create-a-backup/)
-or [How to create and list backups in Charmed PostgreSQL K8s](https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/14/how-to/back-up-and-restore/create-a-backup/) for the full procedure.
+or [How to create and list backups in Charmed PostgreSQL K8s](https://canonical.com/data/postgresql/docs/14/how-to/back-up-and-restore/create-a-backup/) for the full procedure.
 
 To restore Discourse, once it is deployed and configured as the Discourse instance to restore, it is only necessary
 to restore the database. The instructions, depending on the configuration, can be found in the next links:
 
  - Charmed PostgreSQL. Local backup: https://charmhub.io/postgresql/docs/h-restore-backup
- - Charmed PostgreSQL. Migrate a cluster: https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/14/how-to/back-up-and-restore/create-a-backup/
- - Charmed PostgreSQL K8s. Local backup: https://charmhub.io/postgresql-k8s/docs/h-restore-backup
- - Charmed PostgreSQL K8s. Migrate a cluster: https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/14/how-to/back-up-and-restore/migrate-a-cluster/
+ - Charmed PostgreSQL. Migrate a cluster: https://canonical.com/data/postgresql/docs/14/how-to/back-up-and-restore/migrate-a-cluster/
+ - Charmed PostgreSQL K8s. Local backup: https://canonical.com/data/postgresql/docs/14/h-restore-backup/
+ - Charmed PostgreSQL K8s. Migrate a cluster: https://canonical.com/data/postgresql/docs/14/how-to/back-up-and-restore/migrate-a-cluster/
 
 ## S3 and the backup and restore procedure
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Discourse Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview
Fixed broken PostgreSQL/PostgreSQL K8s backup-restore links in `docs/how-to/backup-and-restore.md`.
<!-- A high level overview of the change -->

### Rationale
The old links routed through a `readthedocs-hosted.com` redirect proxy that loops forever, so they were replaced with the stable direct `canonical.com` URLs to fix link checker CI.
<!-- The reason the change is needed -->

### Juju events changes
N/A
<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module changes
N/A
<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library changes
N/A
<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://documentation.ubuntu.com/ops/latest/howto/write-and-structure-charm-code/) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The changelog is updated.
<!-- Explanation for any unchecked items above -->
